### PR TITLE
Fix a filename and pillar key issue

### DIFF
--- a/nginx/common.sls
+++ b/nginx/common.sls
@@ -24,7 +24,7 @@ nginx-logger-{{ log_type }}:
     - user: root
     - group: root
     - mode: 440
-    - source: salt://nginx/templates/upstart_logger.jinja
+    - source: salt://nginx/templates/upstart-logger.jinja
     - context:
       type: {{ log_type }}
   service:

--- a/templates/upstart-logger.jinja
+++ b/templates/upstart-logger.jinja
@@ -1,4 +1,4 @@
-# {{ pillar['message_do_not_modify'] }}
+# {{ pillar.get('message_do_not_modify', '') }}
 # startup script for Nginx loggers
 
 start on starting nginx


### PR DESCRIPTION
- Ensure `common.sls` references correct template filename
- Use `pillar.get(...)` for message_do_not_modify with default
