### PR TITLE
remove extraneous nrpe include (fixes #8)

### DIFF
--- a/nginx/common.sls
+++ b/nginx/common.sls
@@ -1,6 +1,3 @@
-include:
-  - nrpe
-
 /usr/share/nginx:
   file:
     - directory


### PR DESCRIPTION
Issue #8 was for an extra include of a state named nrpe.
