### PR TITLE
fixing bug with common.sls that causes it to fail

### DIFF
--- a/nginx/common.sls
+++ b/nginx/common.sls
@@ -37,14 +37,6 @@ nginx-logger-{{ log_type }}:
   file:
     - absent
 
-{% for dir in ['sites-available', 'sites-enabled'] -%}
-/etc/nginx/{{ dir }}:
-  file.directory:
-    - user: www-data
-    - group: www-data
-    - mode: 0755
-{% endfor -%}
-
 /etc/nginx:
   file.directory:
     - user: root


### PR DESCRIPTION
This is a repeated configuration block, and the directory should be owned by root not www-data, which happens later in the state file. 
