### PR TITLE
Context parameter safety fixes

### DIFF
--- a/nginx/ng/config.sls
+++ b/nginx/ng/config.sls
@@ -11,4 +11,4 @@ nginx_config:
     - source: salt://nginx/ng/files/nginx.conf
     - template: jinja
     - context:
-      config: {{ nginx.server.config }}
+        config: {{ nginx.server.config|json() }}

--- a/nginx/ng/vhosts_config.sls
+++ b/nginx/ng/vhosts_config.sls
@@ -93,7 +93,7 @@ nginx_vhost_available_dir:
     - source: salt://nginx/ng/files/vhost.conf
     - template: jinja
     - context:
-      config: {{ settings.config }}
+        config: {{ settings.config|json() }}
 {% do vhost_states.append(conf_state_id) %}
 {% endif %}
 


### PR DESCRIPTION
Another context oddity reared its head when backslashes started getting doubled quoted. Fixed by forcing context data to json before pushing it forward. Also brings indentation in-line with salt doc 23.14.1.2.1
