### PR TITLE
Feature/misc config items

### DIFF
--- a/nginx/templates/config.jinja
+++ b/nginx/templates/config.jinja
@@ -19,7 +19,7 @@ events {
     {% set use = nginx.get('events', {}).get('use', '') -%}
     {% if use -%}
     use {{ use }};
-    {% endif -%}
+    {% endif %}
 }
 
 http {
@@ -62,7 +62,7 @@ http {
         access_log off;
     }
 {% endif -%}
-{% endif -%}
+{% endif %}
 
     include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/sites-enabled/*.conf;


### PR DESCRIPTION
This simply adds some options to /etc/nginx/nginx.conf that aren't currently configurable via pillar. There are also a few miscellaneous changes, e.g. changes the default error_log location to /var/log/nginx/error.log instead of error.fifo to bring it in line with /etc/logrotate.d/nginx.
