### PR TITLE
fix link to formula usage instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Install nginx either by source or by package.
 
 
     See the full `Salt Formulas installation and usage instructions
-    <http://docs.saltstack.com/topics/conventions/formulas.html>`_.
+    <http://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.
 
 Available states
 ================


### PR DESCRIPTION
current link 404's
