### PR TITLE
Create /var/log/nginx before running mkfifo

### DIFF
--- a/nginx/templates/upstart-logger.jinja
+++ b/nginx/templates/upstart-logger.jinja
@@ -8,6 +8,7 @@ respawn
 
 pre-start script
     if [ ! -r /var/log/nginx/{{ type }}.fifo ]; then
+        mkdir -p /var/log/nginx
         mkfifo /var/log/nginx/{{ type }}.fifo
         chown root.root /var/log/nginx/{{ type }}.fifo
         chmod 660 /var/log/nginx/{{ type }}.fifo


### PR DESCRIPTION
... otherwise, services nginx-logger-{access,error} fail and so is the nginx service eventually. The error was produced under Ubuntu 14.04 and `install_from_source: False`.
