### PR TITLE
Update nginx.conf after installing nginx package

### DIFF
--- a/nginx/common.sls
+++ b/nginx/common.sls
@@ -54,6 +54,9 @@ nginx-logger-{{ log_type }}:
     - source: salt://nginx/templates/config.jinja
     - require:
       - file: /etc/nginx
+{% if not pillar.get('nginx', {}).get('install_from_source') %}
+      - pkg: nginx
+{% endif -%}
 
 {% for dir in ('sites-enabled', 'sites-available') %}
 /etc/nginx/{{ dir }}:


### PR DESCRIPTION
This is another solution proposed for #23. Quoting #23,

> The default of daemon off; is causing salt-minion to hang when executing the nginx service state (i.e. when calling /etc/init.d/nginx start) on Ubuntu 14.04 and 12.04.

However, changing the default value of `daemon` doesn't solve the root cause; the minion would still hang if someone explicitly used `daemon: True` for whatever reason.
