### PR TITLE
Fix errors in source.sls

### DIFF
--- a/nginx/source.sls
+++ b/nginx/source.sls
@@ -72,7 +72,7 @@ get-nginx-{{name}}:
     - watch:
       - file: get-nginx
     - require_in:
-      - cmd: make-nginx
+      - cmd: nginx
 {% endfor -%}
 
 get-ngx_devel_kit:


### PR DESCRIPTION
Installing nginx using `install_from_source: True` was failing due to many issues in the state file. It works just fine applying these edits. Errors were produced using salt 2014.1.4.
