### PR TITLE
Support http_realip module

### DIFF
--- a/nginx/templates/config.jinja
+++ b/nginx/templates/config.jinja
@@ -14,7 +14,7 @@ events {
 
 http {
     {% if 'set_real_ips' in nginx -%}
-    {% for ip in nginx.get('set_real_ips', {}).get('ips', []) -%}
+    {% for ip in nginx.get('set_real_ips', {}).get('from_ips', []) -%}
     set_real_ip_from {{ ip }};
     {% endfor -%}
     real_ip_header {{ nginx.get('set_real_ips', {}).get('real_ip_header', 'X-Forwarded-For') }};

--- a/pillar.example
+++ b/pillar.example
@@ -4,7 +4,7 @@ nginx:
   with_luajit: False
   with_openresty: True
   set_real_ips: # NOTE: to use this, nginx must have http_realip module enabled
-    ips:
+    from_ips:
       - 10.10.10.0/24
     real_ip_header: X-Forwarded-For
   modules:


### PR DESCRIPTION
This would support the `set_real_ip_from` and `real_ip_header` directives provided by the http_realip nginx module. _NOTE_: before this is merged, the currently-closed #28 should be re-opened and possibly expanded upon (i.e. to force nginx install before config file not only via `package.sls`, but also via `source.sls`). The reason is that this pull request causes the nginx.conf template to check 'nginx -V' on the minion, so the nginx binary must be installed before the nginx.conf template compiles.

If there is not interest to complete #28 then:
- this may be closed, or
- I can remove the `nginx -V` check and users must simply use realip via pillar if and only if they know their nginx was compiled with realip. However if a user unwittingly sets realip info in pillar but their nginx does not support it, nginx will fail to start.
