### PR TITLE
Optionally include nginx.users via a pillar value

### DIFF
--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -1,6 +1,8 @@
 include:
   - nginx.common
+{% if pillar.get('nginx', {}).get('user_auth_enabled', true) %}
   - nginx.users
+{% endif %}
 {% if pillar.get('nginx', {}).get('install_from_source') %}
   - nginx.source
 {% else %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,7 @@
 nginx:
   install_from_source: True
   use_upstart: True
+  user_auth_enabled: True
   with_luajit: False
   with_openresty: True
   modules:


### PR DESCRIPTION
This allows one to avoid installing `apache2-utils` and its dependencies if `nginx:user_auth_enabled` is `False`. (defaults to the current behavior).
