### PR TITLE
Fixes missing requisites in ng.init

### DIFF
--- a/nginx/ng/init.sls
+++ b/nginx/ng/init.sls
@@ -17,4 +17,4 @@ extend:
   nginx_config:
     file:
       - require:
-        - pkg: install
+        - pkg: nginx_install


### PR DESCRIPTION
Just a little housecleaning for requisites to ensure that all variations of the states work.
