### PR TITLE
Synchronized upstart script with the one recommended by nginx.

### DIFF
--- a/nginx/templates/upstart.jinja
+++ b/nginx/templates/upstart.jinja
@@ -1,8 +1,23 @@
-# startup script for Nginx
-
-respawn
-
-start on filesystem or runlevel [2345]
+# nginx
+ 
+description "nginx http daemon"
+author "George Shammas <georgyo@gmail.com>"
+ 
+start on (filesystem and net-device-up IFACE=lo)
 stop on runlevel [!2345]
-
-exec /usr/sbin/nginx -c /etc/nginx/nginx.conf
+ 
+env DAEMON=/usr/sbin/nginx
+ 
+expect fork
+respawn
+respawn limit 10 5
+#oom never
+ 
+pre-start script
+        $DAEMON -t
+        if [ $? -ne 0 ]
+                then exit $?
+        fi
+end script
+ 
+exec $DAEMON


### PR DESCRIPTION
This fixes problems with nginx respawning too many times because upstart was not tracking the process correctly.

http://wiki.nginx.org/Upstart

You can test this by ensuring that the process id of the nginx master matches what is being reported by upstart (i.e. `service nginx status`). Also verify that nginx is not respawning repeatedly by looking in the `error.log` configured for nginx.
