### PR TITLE
Installing nginx on Ubuntu/Debian fails, missing map property

### DIFF
--- a/nginx/map.jinja
+++ b/nginx/map.jinja
@@ -1,6 +1,7 @@
 {% set nginx = salt['grains.filter_by']({
     'Debian': {
         'apache_utils': 'apache2-utils',
+        'package': 'nginx-full'
     },
     'RedHat': {
         'apache_utils': 'httpd-tools',


### PR DESCRIPTION
Using in top.sls state `nginx.package` was failing because of missing map
