### PR TITLE
Fix support for os_family RedHat

### DIFF
--- a/nginx/common.sls
+++ b/nginx/common.sls
@@ -1,3 +1,4 @@
+{% from "nginx/map.jinja" import nginx as nginx_map with context %}
 {% set nginx = pillar.get('nginx', {}) -%}
 {% set home = nginx.get('home', '/var/www') -%}
 {% set conf_dir = nginx.get('conf_dir', '/etc/nginx') -%}
@@ -6,8 +7,8 @@
 {{ home }}:
   file:
     - directory
-    - user: www-data
-    - group: www-data
+    - user: {{ nginx_map.default_user }}
+    - group: {{ nginx_map.default_user }}
     - mode: 0755
     - makedirs: True
 
@@ -36,3 +37,13 @@
     - source: {{ conf_template }}
     - require:
       - file: {{ conf_dir }}
+    - context:
+      default_user: {{ nginx_map.default_user }}
+      default_group: {{ nginx_map.default_group }}
+
+{% for dir in ('sites-enabled', 'sites-available') %}
+/etc/nginx/{{ dir }}:
+  file.directory:
+    - user: root
+    - group: root
+{% endfor -%}

--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -1,8 +1,9 @@
 include:
   - nginx.common
+# Only upstart OR sysvinit should default to true.
 {% if pillar.get('nginx', {}).get('use_upstart', true) %}
   - nginx.upstart
-{% elif pillar.get('nginx', {}).get('use_sysvinit', true) %}
+{% elif pillar.get('nginx', {}).get('use_sysvinit', false) %}
   - nginx.sysvinit
 {% endif %}
 {% if pillar.get('nginx', {}).get('user_auth_enabled', true) %}

--- a/nginx/map.jinja
+++ b/nginx/map.jinja
@@ -1,9 +1,18 @@
 {% set nginx = salt['grains.filter_by']({
     'Debian': {
         'apache_utils': 'apache2-utils',
-        'package': 'nginx-full'
+        'package': 'nginx-full',
+        'default_user': 'www-data',
+        'default_group': 'www-data',
+        'disable_before_rename': False,
+        'old_init_disable': 'update-rc.d -f nginx remove'
     },
     'RedHat': {
         'apache_utils': 'httpd-tools',
+        'package': 'nginx',
+        'default_user': 'nginx',
+        'default_group': 'nginx',
+        'disable_before_rename': True,
+        'old_init_disable': 'chkconfig --del nginx'
     },
-}, merge=salt['pillar.get']('nginx:lookup')) %}
+}, merge=salt['pillar.get']('nginx:lookup'), default='Debian') %}

--- a/nginx/source.sls
+++ b/nginx/source.sls
@@ -1,3 +1,5 @@
+# Source currently requires package 'build-essential' which is Debian based.
+# Will not work with os_family RedHat!  You have been warned.
 {% set nginx = pillar.get('nginx', {}) -%}
 {% set version = nginx.get('version', '1.6.2') -%}
 {% set checksum = nginx.get('checksum', 'sha256=b5608c2959d3e7ad09b20fc8f9e5bd4bc87b3bc8ba5936a513c04ed8f1391a18') -%}
@@ -137,6 +139,11 @@ nginx:
       - cmd: get-nginx
       {% for name, module in nginx.get('modules', {}).items() -%}
       - file: get-nginx-{{name}}
+      {% endfor %}
+    - watch_in:
+      {% set logger_types = ('access', 'error') %}
+      {% for log_type in logger_types %}  
+      - service: nginx-logger-{{ log_type }}
       {% endfor %}
     - require:
       - cmd: get-nginx

--- a/nginx/sysvinit.sls
+++ b/nginx/sysvinit.sls
@@ -15,19 +15,25 @@ nginx-logger-{{ log_type }}:
     - user: root
     - group: root
     - mode: 755
-    - source: salt://nginx/templates/sysvinit-logger.jinja
+    - source:
+      - salt://nginx/templates/{{ grains['os_family'] }}-sysvinit-logger.jinja
+      - salt://nginx/templates/sysvinit-logger.jinja
     - context:
       type: {{ log_type }}
   service:
     - running
     - enable: True
     - restart: True
-    - watch:
-      - cmd: nginx
     - require:
       - file: nginx-logger-{{ log_type }}
     - require_in:
       - service: nginx
+# Not supported in os_family other than Debian
+{% if grains['os_family'] == 'Debian' %}
+  cmd:
+    - wait
+    - name: /usr/sbin/update-rc.d nginx-logger-{{ log_type }} defaults
+{% endif %}
 {% endfor %}
 
 /etc/logrotate.d/nginx:

--- a/nginx/templates/RedHat-sysvinit-logger.jinja
+++ b/nginx/templates/RedHat-sysvinit-logger.jinja
@@ -1,0 +1,100 @@
+#!/bin/bash
+# /etc/init.d/nginx-logger-{{ type }}
+#
+# chkconfig: 345 84 16
+# description: Nginx logger for {{ type }}
+# processname: nginx-logger-{{ type }}
+
+NAME=nginx-logger-{{ type }}
+DESC="syslog forwarder for nginx {{type}} logs"
+DAEMON=/usr/bin/logger
+DAEMON_ARGS=" -f /var/log/nginx/{{ type }}.fifo -t nginx -p {% if type == 'error' %}warn{% else %}debug{% endif %}"
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the daemon program isn't installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+. /etc/init.d/functions
+
+do_start() {
+	# Return
+	# 0 if daemon has been started
+	# 1 if daemon was already running
+	# 2 if daemon could not be started
+        echo -n "Starting $NAME"
+        pid=$(cat $PIDFILE 2>/dev/null)
+	if [ -n "$pid" ]; then
+                failure
+                echo
+		return 1;
+	fi
+
+	if [ ! -r /var/log/nginx/{{ type }}.fifo ]; then
+		mkdir -p /var/log/nginx
+		mkfifo /var/log/nginx/{{ type }}.fifo
+		chown root.root /var/log/nginx/{{ type }}.fifo
+		chmod 660 /var/log/nginx/{{ type }}.fifo
+	fi
+
+        $DAEMON $DAEMON_ARGS &
+        ERROR=$?
+        PID=$!
+        if [ $ERROR -eq 0 ]; then
+                success
+                echo
+                echo $PID > $PIDFILE
+        else
+                failure
+                echo
+                exit 2
+        fi
+}
+
+do_stop() {
+	# Return
+	# 0 if daemon has been stopped
+	# 1 if daemon was already stopped
+	# 2 if daemon could not be stopped
+	# other if a failure occurred
+        echo -n Stopping $NAME
+        pid=$(cat $PIDFILE 2>/dev/null)
+        if [ $? -eq 0 ]; then
+                echo $pid | xargs kill 2&1>/dev/null
+                success
+                RETVAL=0
+        else
+                failure
+                RETVAL=1
+        fi
+        echo
+
+	[ "$RETVAL" = 2 ] && return 2
+	rm -f $PIDFILE
+	return "$RETVAL"
+}
+
+case "$1" in
+	start)
+		do_start
+		;;
+	stop)
+		do_stop
+		;;
+	status)
+                status -p "$PIDFILE" "$DAEMON" && exit 0 || exit $?
+		;;
+	restart|force-reload)
+		do_stop
+		do_start
+		;;
+	*)
+		echo "Usage: /etc/init.d/nginx-logger-{{ type }} {start|stop|status|restart|force-reload}" >&2
+		exit 3
+		;;
+esac
+
+exit 0

--- a/nginx/templates/config.jinja
+++ b/nginx/templates/config.jinja
@@ -1,6 +1,7 @@
 {% set nginx = pillar.get('nginx', {}) -%}
-{% set user = nginx.get('user', 'www-data') -%}
-{% set group = nginx.get('group', 'www-data') -%}
+# defaults passed via context from the map.jinja
+{% set user = nginx.get('user', default_user) -%}
+{% set group = nginx.get('group', default_group) -%}
 user   {{ user }} {{ group }};
 worker_processes  {{ nginx.get('worker_processes', 1) }};
 {% set worker_rlimit_nofile = nginx.get('worker_rlimit_nofile', '') -%}


### PR DESCRIPTION
This set of changes should make the base formula (did not touch the ng formula as I needed something working on 2014.1.x) work with the os_family RedHat.  Currently I have no issues if I use the upstart version of the formula whatsoever.  However, when utilizing the sysvinit version, I am running into locking in the nginx loggers and the nginx sysvinit services.  I would guess it is related to some subprocess interaction similar to https://github.com/saltstack/salt/issues/14957, but maybe someone else has an idea.

I still wanted to share the PR because, as I said, it at least works well with upstart with these changes in place, and even sysvinit is in better shape for the RedHat family than before.  It may be worth noting that the init scripts might be able to be changed to support lsb style init functions, but redhat-lsb would become a package dependency, and it can be extra bloat people may not want.

If there are any changes you would like to see before accepting this pull, please let me know, and I would be happy to assist.  I am also generally on IRC in #salt as SheetiS if you would like to discuss real-time.
