### PR TITLE
Use nginx_map.default_group for group in all places

### DIFF
--- a/nginx/common.sls
+++ b/nginx/common.sls
@@ -8,7 +8,7 @@
   file:
     - directory
     - user: {{ nginx_map.default_user }}
-    - group: {{ nginx_map.default_user }}
+    - group: {{ nginx_map.default_group }}
     - mode: 0755
     - makedirs: True
 


### PR DESCRIPTION
@nmadhok This should be the fix you requested.  I didn't find it anywhere else with a quick grep through everything.  Thanks for the catch!
