### PR TITLE
Force overwrite of /etc/init.d/nginx

### DIFF
--- a/nginx/package.sls
+++ b/nginx/package.sls
@@ -10,6 +10,7 @@ nginx-old-init:
       - file: nginx
     - require:
       - pkg: nginx
+    - force: True
 {% if grains.get('os_family') == 'Debian' %}
 # Don't dpkg-divert if we are not Debian based!
   cmd:


### PR DESCRIPTION
Without `force`, the nginx-old-init file.rename state will fail after its initial run. Force prevents it from failing, but also presumes that the target, '/usr/share/nginx/init.d' is safe to overwrite. Maybe someone that knows more about this formula can review this PR.
