### PR TITLE
nginx config default should use the error.fifo

### DIFF
--- a/nginx/templates/config.jinja
+++ b/nginx/templates/config.jinja
@@ -9,7 +9,7 @@ worker_processes  {{ nginx.get('worker_processes', 1) }};
 worker_rlimit_nofile {{ worker_rlimit_nofile }};
 {% endif -%}
 
-{% set error_log_location = nginx.get('error_log',{}).get('location', '/var/log/nginx/error.log') -%}
+{% set error_log_location = nginx.get('error_log',{}).get('location', '/var/log/nginx/error.fifo') -%}
 {% set error_log_level = nginx.get('error_log',{}).get('level', 'warn') -%}
 error_log {{ ' '.join([error_log_location, error_log_level]) }};
 pid {{ nginx.get('pid', '/var/run/nginx.pid') }};


### PR DESCRIPTION
The default config doesn't use the error.fifo created by the the nginx-logger-error service, but the formula does do a file.absent on error.log.
