### PR TITLE
changed ng vhost-disable behavior from renaming to recreating

### DIFF
--- a/nginx/ng/vhosts_config.sls
+++ b/nginx/ng/vhosts_config.sls
@@ -33,7 +33,7 @@
 
 # Gets the current canonical name of a vhost
 {% macro vhost_curpath(vhost) -%}
-  {{ vhost_path(vhost, nginx.vhosts.managed.get(vhost).get('available')) }}
+  {{ vhost_path(vhost, nginx.vhosts.managed.get(vhost).get('enabled')) }}
 {%- endmacro %}
 
 # Creates the sls block that manages symlinking / renaming vhosts
@@ -46,20 +46,16 @@
     - name: {{ vhost_path(vhost, state) }}
     - target: {{ vhost_path(vhost, anti_state) }}
     {%- else %}
-  file.rename:
-    {{ sls_block(nginx.vhosts.rename_opts) }}
-    - name: {{ vhost_path(vhost, state) }}
-    - source: {{ vhost_path(vhost, anti_state) }}
+  file.absent:
+    - name: {{ vhost_path(vhost, anti_state) }}
     {%- endif %}
   {%- elif state == False %}
     {%- if nginx.lookup.vhost_use_symlink %}
   file.absent:
     - name: {{ vhost_path(vhost, anti_state) }}
     {%- else %}
-  file.rename:
-    {{ sls_block(nginx.vhosts.rename_opts) }}
-    - name: {{ vhost_path(vhost, state) }}
-    - source: {{ vhost_path(vhost, anti_state) }}
+  file.absent:
+    - name: {{ vhost_path(vhost, anti_state) }}
     {%- endif -%}
   {%- endif -%}
 {%- endmacro %}


### PR DESCRIPTION
I would suggest to switch the current approach of renaming files to delete and (eventually) recreate the vhost file under a disabled name, because the current system is struggling when disabling pillar-managed vhosts

On the first call everything is cool:
- enabled vhost file is ok
- renaming the file to ".disabled"

On the second run thing get dirty:
- enabled vhost-file is missing -> recreating
- renaming the file to ".disabled" -> ERROR: caused by a existing file

Even when the vhost-file-path would targeting the ".disabled" version (bug?) the rename step would go into the void. 

If we simply change the states from managed to absent when a vhost is disabled this can never happen and be called as many times a needed.

Have I missed some downsides of this approach? If so, please give me some advice how to fix this issue "the right way".
Thanks!
