### PR TITLE
added test for value None, to be an absent value

### DIFF
--- a/nginx/ng/files/nginx.conf
+++ b/nginx/ng/files/nginx.conf
@@ -1,6 +1,7 @@
 {% set indent_increment = 4 %}
 
 {%- macro nginx_block(value, key=None, operator=' ', delim=';', ind=0) -%}
+    {%- if value != None -%}
     {%- if value is number or value is string -%}
         {{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
     {%- elif value is mapping -%}
@@ -15,6 +16,8 @@
         {%- endfor -%}
     {%- else -%}
         {{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
+    {%- endif -%}
+    {%- else -%}
     {%- endif -%}
 {%- endmacro -%}
 


### PR DESCRIPTION
this is needed on archlinux where the pid file is set by systemd
not the nginx.conf file.

In the pillar file you just add
  pid:

an value of 'None' and no pid entry in nginx.conf.
this now works with every None value set in the pillar file