### PR TITLE
Add nginx repo for RedHat family

### DIFF
--- a/nginx/ng/install.sls
+++ b/nginx/ng/install.sls
@@ -48,3 +48,21 @@ nginx_zypp_repo:
     - watch_in:
       - pkg: nginx_install
 {% endif %}
+
+{% if salt['grains.get']('os_family') == 'RedHat' %}
+nginx_yum_repo:
+  pkgrepo.managed:
+    - name: nginx
+    - humanname: nginx repo
+    {%- if salt['grains.get']('os') == 'CentOS' %}
+    - baseurl: 'http://nginx.org/packages/centos/$releasever/$basearch/'
+    {%- else %}
+    - baseurl: 'http://nginx.org/packages/rhel/$releasever/$basearch/'
+    {%- endif %}
+    - gpgcheck: False
+    - enabled: True
+    - require_in:
+      - pkg: nginx_install
+    - watch_in:
+      - pkg: nginx_install
+{% endif %}


### PR DESCRIPTION
This PR will enable nginx-formula to install newest version of nginx from official repo on RedHat family distributions.