### PR TITLE
Fix for incorrect pkg repo base url on Amazon Linux on EC2

### DIFF
--- a/nginx/ng/install.sls
+++ b/nginx/ng/install.sls
@@ -55,7 +55,7 @@ nginx_yum_repo:
     - name: nginx
     - humanname: nginx repo
     {%- if salt['grains.get']('os') == 'CentOS' %}
-    - baseurl: 'http://nginx.org/packages/centos/{{ nginx.lookup.rh_os_releasever }}/$basearch/'
+    - baseurl: 'http://nginx.org/packages/centos/$releasever/$basearch/'
     {%- else %}
     - baseurl: 'http://nginx.org/packages/rhel/{{ nginx.lookup.rh_os_releasever }}/$basearch/'
     {%- endif %}

--- a/nginx/ng/install.sls
+++ b/nginx/ng/install.sls
@@ -55,9 +55,9 @@ nginx_yum_repo:
     - name: nginx
     - humanname: nginx repo
     {%- if salt['grains.get']('os') == 'CentOS' %}
-    - baseurl: 'http://nginx.org/packages/centos/$releasever/$basearch/'
+    - baseurl: 'http://nginx.org/packages/centos/{{ nginx.lookup.rh_os_releasever }}/$basearch/'
     {%- else %}
-    - baseurl: 'http://nginx.org/packages/rhel/$releasever/$basearch/'
+    - baseurl: 'http://nginx.org/packages/rhel/{{ nginx.lookup.rh_os_releasever }}/$basearch/'
     {%- endif %}
     - gpgcheck: False
     - enabled: True

--- a/nginx/ng/map.jinja
+++ b/nginx/ng/map.jinja
@@ -25,6 +25,7 @@
             'vhost_enabled': '/etc/nginx/conf.d',
             'vhost_use_symlink': False,
             'pid_file': '/var/run/nginx.pid',
+            'rh_os_releasever': '$releasever',
         },
         'Suse': {
             'package': 'nginx',

--- a/nginx/ng/map.jinja
+++ b/nginx/ng/map.jinja
@@ -24,7 +24,10 @@
             'vhost_available': '/etc/nginx/conf.d',
             'vhost_enabled': '/etc/nginx/conf.d',
             'vhost_use_symlink': False,
+<<<<<<< HEAD
             'pid_file': '/var/run/nginx.pid',
+=======
+>>>>>>>  * added pillar variable to specify os release version for nginx package repo base url for RedHat family os hosts
             'rh_os_releasever': '$releasever',
         },
         'Suse': {

--- a/nginx/ng/map.jinja
+++ b/nginx/ng/map.jinja
@@ -24,10 +24,7 @@
             'vhost_available': '/etc/nginx/conf.d',
             'vhost_enabled': '/etc/nginx/conf.d',
             'vhost_use_symlink': False,
-<<<<<<< HEAD
             'pid_file': '/var/run/nginx.pid',
-=======
->>>>>>>  * added pillar variable to specify os release version for nginx package repo base url for RedHat family os hosts
             'rh_os_releasever': '$releasever',
         },
         'Suse': {

--- a/pillar.example
+++ b/pillar.example
@@ -35,6 +35,7 @@ nginx:
       vhost_available: /etc/nginx/sites-available
       vhost_enabled: /etc/nginx/sites-enabled
       vhost_use_symlink: True
+      # This is required for RedHat like distros (Amazon Linux) that don't follow semantic versioning for $releasever
       rh_os_releasever: '6'
 
     # Source compilation is not currently a part of nginx.ng

--- a/pillar.example
+++ b/pillar.example
@@ -35,6 +35,7 @@ nginx:
       vhost_available: /etc/nginx/sites-available
       vhost_enabled: /etc/nginx/sites-enabled
       vhost_use_symlink: True
+      rh_os_releasever: '6'
 
     # Source compilation is not currently a part of nginx.ng
     from_source: False


### PR DESCRIPTION
On Amazon Linux on EC2 - $releasever variable is set to 'latest' resulting in incorrect nginx repo url. As per http://wiki.nginx.org/Install#Official_Red_Hat.2FCentOS_packages $releasever needs to be set manually as per OS version.

Created a pillar variable nginx:ng:lookup:rh_os_releasever for the above. Default value for the pillar variable is '$releasever' 