### PR TITLE
Added nginx.ng.certificates state.

### DIFF
--- a/nginx/ng/certificates.sls
+++ b/nginx/ng/certificates.sls
@@ -1,0 +1,23 @@
+include:
+  - nginx.ng.service
+
+{%- for domain in salt['pillar.get']('nginx:ng:certificates', {}).keys() %}
+
+nginx_{{ domain }}_ssl_certificate:
+  file.managed:
+    - name: /etc/nginx/ssl/{{ domain }}.crt
+    - makedirs: True
+    - contents_pillar: nginx:ng:certificates:{{ domain }}:public_cert
+    - watch_in:
+      - service: nginx_service
+
+nginx_{{ domain }}_ssl_key:
+  file.managed:
+    - name: /etc/nginx/ssl/{{ domain }}.key
+    - mode: 600
+    - makedirs: True
+    - contents_pillar: nginx:ng:certificates:{{ domain }}:private_key
+    - watch_in:
+      - service: nginx_service
+
+{%- endfor %}

--- a/nginx/ng/init.sls
+++ b/nginx/ng/init.sls
@@ -6,6 +6,7 @@ include:
   - nginx.ng.config
   - nginx.ng.service
   - nginx.ng.vhosts
+  - nginx.ng.certificates
 
 extend:
   nginx_service:

--- a/pillar.example
+++ b/pillar.example
@@ -106,3 +106,23 @@ nginx:
           #        test something else;
           #    }
           # }         
+
+    # If you're doing SSL termination, you can deploy certificates this way.
+    # The private one(s) should go in a separate pillar file not in version
+    # control (or use encrypted pillar data).
+    certificates:
+      'www.example.com':
+        public_cert: |
+          -----BEGIN CERTIFICATE-----
+          (Your Primary SSL certificate: www.example.com.crt)
+          -----END CERTIFICATE-----
+          -----BEGIN CERTIFICATE-----
+          (Your Intermediate certificate: ExampleCA.crt)
+          -----END CERTIFICATE-----
+          -----BEGIN CERTIFICATE-----
+          (Your Root certificate: TrustedRoot.crt)
+          -----END CERTIFICATE-----
+        private_key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          (Your Private Key: www.example.com.key)
+          -----END RSA PRIVATE KEY-----


### PR DESCRIPTION
I keep having to write my own states to manage nginx vhost certificates and keys. It seems like the sort of thing that should be built in to nginx-formula.

This implements it as a separate state, as simply as I could come up with. It occurred to me after writing this that it would be nice if it could detect ssl settings in a server definition and look for a matching cert/key in pillar automatically, but that could get complicated.