### PR TITLE
Add support for building from source with os_family=RedHat

### DIFF
--- a/nginx/map.jinja
+++ b/nginx/map.jinja
@@ -22,7 +22,7 @@
     },
     'RedHat': {
         'apache_utils': 'httpd-tools',
-        'group_action': 'pkg.group_install',
+        'group_action': 'pkg.group_installed',
         'group_pkg': 'Development Tools',
         'libpcre_dev': 'pcre-devel',
         'libssl_dev': 'openssl-devel',

--- a/nginx/map.jinja
+++ b/nginx/map.jinja
@@ -1,6 +1,11 @@
 {% set nginx = salt['grains.filter_by']({
     'Debian': {
         'apache_utils': 'apache2-utils',
+        'group_action': 'pkg.installed',
+        'group_pkg': 'build-essential',
+        'libpcre_dev': 'libpcre3-dev',
+        'libssl_dev': 'libssl-dev',
+        'pid_path': '/var/run/nginx.pid',
         'package': 'nginx-full',
         'default_user': 'www-data',
         'default_group': 'www-data',
@@ -17,6 +22,11 @@
     },
     'RedHat': {
         'apache_utils': 'httpd-tools',
+        'group_action': 'pkg.group_install',
+        'group_pkg': 'Development Tools',
+        'libpcre_dev': 'pcre-devel',
+        'libssl_dev': 'openssl-devel',
+        'pid_path': '/run/nginx.pid',
         'package': 'nginx',
         'default_user': 'nginx',
         'default_group': 'nginx',
@@ -31,4 +41,4 @@
         'install_prefix': '/usr/local/nginx',
         'make_flags': '-j2'
     },
-}, merge=salt['pillar.get']('nginx:lookup'), default='Debian') %}
+}, grain='os_family', merge=salt['pillar.get']('nginx:lookup'), default='Debian') %}

--- a/nginx/ng/map.jinja
+++ b/nginx/ng/map.jinja
@@ -24,7 +24,7 @@
             'vhost_available': '/etc/nginx/conf.d',
             'vhost_enabled': '/etc/nginx/conf.d',
             'vhost_use_symlink': False,
-            'pid_file': '/var/run/nginx.pid',
+            'pid_file': '/run/nginx.pid',
             'rh_os_releasever': '$releasever',
         },
         'Suse': {

--- a/nginx/source.sls
+++ b/nginx/source.sls
@@ -65,7 +65,7 @@ nginx_user:
     - makedirs: True
 
 get-build-tools:
-{% if salt['pkg.version']('salt') <= '2015.8.0' and grains['os_family'] == 'RedHat' %}
+{% if salt['pkg.version']('salt') < '2015.8.0' and grains['os_family'] == 'RedHat' %}
   module.run:
     - name: pkg.group_install
     - m_name: {{ nginx_map.group_pkg }}

--- a/nginx/source.sls
+++ b/nginx/source.sls
@@ -65,7 +65,7 @@ nginx_user:
     - makedirs: True
 
 get-build-tools:
-{% if salt['pkg.version']('salt') < '2015.8.0' and grains['os_family'] == 'RedHat' %}
+{% if grains['saltversion'] < '2015.8.0' and grains['os_family'] == 'RedHat' %}
   module.run:
     - name: pkg.group_install
     - m_name: {{ nginx_map.group_pkg }}

--- a/nginx/source.sls
+++ b/nginx/source.sls
@@ -1,8 +1,5 @@
 {% from "nginx/map.jinja" import nginx as nginx_map with context %}
 
-# Source currently requires package 'build-essential' which is Debian based.
-# Will not work with os_family RedHat!
-# TODO- Someone with a RedHat system please update this to work on RedHat
 {% set nginx = pillar.get('nginx', {}) -%}
 {% set use_sysvinit = nginx.get('use_sysvinit', nginx_map['use_sysvinit']) %}
 {% set version = nginx.get('version', '1.6.2') -%}
@@ -15,7 +12,7 @@
 {% set conf_dir = nginx.get('conf_dir', nginx_map['conf_dir']) -%}
 {% set conf_only = nginx.get('conf_only', false) -%}
 {% set log_dir = nginx.get('log_dir', nginx_map['log_dir']) -%}
-{% set pid_path = nginx.get('pid_path', '/var/run/nginx.pid') -%}
+{% set pid_path = nginx.get('pid_path', nginx_map['pid_path']) -%}
 {% set lock_path = nginx.get('lock_path', '/var/lock/nginx.lock') -%}
 {% set sbin_dir = nginx.get('sbin_dir', nginx_map['sbin_dir']) -%}
 
@@ -67,12 +64,22 @@ nginx_user:
     - directory
     - makedirs: True
 
+get-build-tools:
+{% if salt['pkg.version']('salt') <= '2015.8.0' and grains['os_family'] == 'RedHat' %}
+  module.run:
+    - name: pkg.group_install
+    - m_name: {{ nginx_map.group_pkg }}
+{% else %}
+  {{ nginx_map.group_action }}:
+    - name: {{ nginx_map.group_pkg }}
+{% endif %}
+
 get-nginx:
   pkg.installed:
     - names:
-      - libpcre3-dev
-      - build-essential
-      - libssl-dev
+      - {{ nginx_map.libpcre_dev }}
+      - {{ nginx_map.libssl_dev }}
+
   file.managed:
     - name: {{ nginx_package }}
     - source: {{ tarball_url }}
@@ -218,6 +225,7 @@ nginx:
       {% for name, module in nginx.get('modules', {}).items() -%}
       - file: get-nginx-{{name}}
       {% endfor %}
+{% if use_sysvinit %}
   file:
     - managed
     - template: jinja
@@ -230,6 +238,7 @@ nginx:
       service_name: {{ service_name }}
       sbin_dir: {{ sbin_dir }}
       pid_path: {{ pid_path }}
+{% endif %}
   service:
 {% if service_enable %}
     - running


### PR DESCRIPTION
Updated source.sls for building in RedHat, CentOS and probably Fedora. The needed packages are selected by map.jinja based on grain=os_family in order to support Ubuntu/Debian or RedHat/CentOS/Fedora. 

While in Debian based systems we install build-essential package for all development tools, in RedHat based we can use the group 'Development Tools'. Saltstack development versions provides [pkg.group_installed](http://docs.saltstack.com/en/develop/ref/states/all/salt.states.pkg.html#salt.states.pkg.group_installed) state but as it's not available in stable versions yet I had to do a fallback to [pkg.group_install](http://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.yumpkg.html#salt.modules.yumpkg.group_install) module if salt version is older than ` 2015.8.0`. 

I've tested it in CentOS 7, RedHat 7.1 and Ubuntu 14.10 (Utopic Unicorn).