### PR TITLE
Resolve missing dependency for nginx home dir.

### DIFF
--- a/nginx/common.sls
+++ b/nginx/common.sls
@@ -11,6 +11,13 @@
     - group: {{ nginx_map.default_group }}
     - mode: 0755
     - makedirs: True
+    - require:
+      {%- if pillar.get('nginx', {}).get('install_from_source', false) %}
+      - user: {{ nginx_map.default_user }}
+      - group: {{ nginx_map.default_group }}
+      {%- else %}
+      - pkg: nginx
+      {% endif %}
 
 /usr/share/nginx:
   file:


### PR DESCRIPTION
To resolve the occurrence of the below error, a dependency has been added to require the nginx user first be created, either by nginx package installation or explicitly with salt (when installing nginx from source).

```
----------
          ID: /var/www
    Function: file.directory
      Result: False
     Comment: User nginx is not available Group nginx is not available
     Started: 15:50:02.070799
    Duration: 0.531 ms
     Changes:
----------
```

I first encountered the error while using the [puppetlabs/centos-7.0-64-nocm](https://atlas.hashicorp.com/puppetlabs/boxes/centos-7.0-64-nocm/versions/1.0.2) Vagrant box and attempting to provision nginx-formula with salt. At the time, the pillar only included the following:

```
nginx: 
  use_upstart: False
```