### PR TITLE
Adding default include for 'sites-enabled' dir

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -63,6 +63,7 @@ nginx:
           include:
             - /etc/nginx/mime.types
             - /etc/nginx/conf.d/*.conf
+            - /etc/nginx/sites-enabled/*
 
     vhosts:
       disabled_postfix: .disabled # a postfix appended to files when doing non-symlink disabling


### PR DESCRIPTION
This `include` appears in the default Nginx config file and I think it should also be in the pillar example as most of the setups place the active vhosts in there.