### PR TITLE
Workaround for include being defined too early

### DIFF
--- a/nginx/ng/files/nginx.conf
+++ b/nginx/ng/files/nginx.conf
@@ -7,8 +7,13 @@
     {%- elif value is mapping -%}
         {{ key|indent(ind, True) }}{{ operator }}{{ '{' }}
         {%- for k, v in value.items() %}
+        {%- if k != 'include' %}
 {{ nginx_block(v, k, operator, delim, (ind + indent_increment)) }}
+        {%- endif %}
         {%- endfor %}
+        {%- if 'include' in value.keys() %}
+{{ nginx_block(value['include'], 'include', operator, delim, (ind + indent_increment)) }}
+        {%- endif %}
 {{ '}'|indent(ind, True) }}
     {%- elif value is iterable -%}
         {%- for v in value %}


### PR DESCRIPTION
This is crap but configuration for http scope cannot be both ordered and
merged from map.jinja it seems, see issue #40.