### PR TITLE
[slspath] make paths generic so the formula can be placed anywhere

### DIFF
--- a/nginx/common.sls
+++ b/nginx/common.sls
@@ -2,7 +2,7 @@
 {% set nginx = pillar.get('nginx', {}) -%}
 {% set home = nginx.get('home', '/var/www') -%}
 {% set conf_dir = nginx.get('conf_dir', '/etc/nginx') -%}
-{% set conf_template = nginx.get('conf_template', 'salt://nginx/templates/config.jinja') -%}
+{% set conf_template = nginx.get('conf_template', 'salt://' + slspath + '/templates/config.jinja') -%}
 
 {{ home }}:
   file:

--- a/nginx/common.sls
+++ b/nginx/common.sls
@@ -1,4 +1,4 @@
-{% from "nginx/map.jinja" import nginx as nginx_map with context %}
+{% from slspath + "/map.jinja" import nginx as nginx_map with context %}
 {% set nginx = pillar.get('nginx', {}) -%}
 {% set home = nginx.get('home', '/var/www') -%}
 {% set conf_dir = nginx.get('conf_dir', '/etc/nginx') -%}

--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -1,18 +1,18 @@
-{% from "nginx/map.jinja" import nginx as nginx_map with context %}
+{% from slspath + "/map.jinja" import nginx as nginx_map with context %}
 
 include:
-  - nginx.common
+  - {{ slspath }}.common
 {% if salt['pillar.get']('nginx:use_upstart', nginx_map['use_upstart']) %}
-  - nginx.upstart
+  - {{ slspath }}.upstart
 {% elif salt['pillar.get']('nginx:use_sysvinit', nginx_map['use_sysvinit']) %}
-  - nginx.sysvinit
+  - {{ slspath }}.sysvinit
 {% endif %}
 {% if pillar.get('nginx', {}).get('user_auth_enabled', true) %}
-  - nginx.users
+  - {{ slspath }}.users
 {% endif %}
 {% if pillar.get('nginx', {}).get('install_from_source', false) %}
-  - nginx.source
+  - {{ slspath }}.source
 {% else %}
-  - nginx.package
+  - {{ slspath }}.package
 {% endif -%}
 

--- a/nginx/package.sls
+++ b/nginx/package.sls
@@ -1,4 +1,4 @@
-{% from "nginx/map.jinja" import nginx with context %}
+{% from slspath + "/map.jinja" import nginx with context %}
 {% set use_upstart = salt['pillar.get']('nginx:use_upstart', nginx['use_upstart']) %}
 {% if use_upstart %}
 nginx-old-init:

--- a/nginx/package.sls
+++ b/nginx/package.sls
@@ -97,7 +97,7 @@ nginx:
     - user: root
     - group: root
     - mode: 440
-    - source: salt://nginx/templates/upstart.jinja
+    - source: salt://{{ slspath }}/templates/upstart.jinja
     - require:
       - pkg: nginx
       - file: nginx-old-init

--- a/nginx/source.sls
+++ b/nginx/source.sls
@@ -230,7 +230,7 @@ nginx:
     - managed
     - template: jinja
     - name: /etc/init.d/{{ service_name }}
-    - source: salt://nginx/templates/nginx.init.jinja
+    - source: salt://{{ slspath }}/templates/nginx.init.jinja
     - user: root
     - group: root
     - mode: 0755

--- a/nginx/sysvinit.sls
+++ b/nginx/sysvinit.sls
@@ -16,8 +16,8 @@ nginx-logger-{{ log_type }}:
     - group: root
     - mode: 755
     - source:
-      - salt://nginx/templates/{{ grains['os_family'] }}-sysvinit-logger.jinja
-      - salt://nginx/templates/sysvinit-logger.jinja
+      - salt://{{ slspath }}/templates/{{ grains['os_family'] }}-sysvinit-logger.jinja
+      - salt://{{ slspath }}/templates/sysvinit-logger.jinja
     - context:
       type: {{ log_type }}
   service:

--- a/nginx/upstart.sls
+++ b/nginx/upstart.sls
@@ -12,7 +12,7 @@ nginx-logger-{{ log_type }}:
     - user: root
     - group: root
     - mode: 440
-    - source: salt://nginx/templates/upstart-logger.jinja
+    - source: salt://{{ slspath }}/templates/upstart-logger.jinja
     - context:
       type: {{ log_type }}
   service:

--- a/nginx/users.sls
+++ b/nginx/users.sls
@@ -1,4 +1,4 @@
-{% from "nginx/map.jinja" import nginx with context %}
+{% from slspath + "/map.jinja" import nginx with context %}
 {% set htauth = nginx.get('htpasswd', '/etc/nginx/.htpasswd') -%}
 
 htpasswd:


### PR DESCRIPTION
At the moment we hardcode the slspath to `nginx` in some places.
This prevents me from placing many `saltstack-formulas` together, and forces me to add a repo root for each one.
Moreover, if I had two different nginx formulas, I wouldn't be able to rename them to resolve the collision, (or I would get unexpected behavior if it did work by loading the other formula)

Basically, it allows my top.sls to look like this:

``` yaml
"web*":
  - saltstack.nginx.nginx
  - saltstack.ntp.ntp
  - my.nginx.vhost
  - my.nginx.tweaks
  - my.ntp.servers
```

The `ntp.ntp` is a little ugly, but that's how it works out with the formula repo structure.
This approach allows me to use the community formulas for the broad strokes, and make any specific changes that no one else would be interested in with my own formulas.
