### PR TITLE
Added support to control gpgcheck and gpgkey via pillar

### DIFF
--- a/nginx/ng/install.sls
+++ b/nginx/ng/install.sls
@@ -41,8 +41,8 @@ nginx_zypp_repo:
     - baseurl: 'http://download.opensuse.org/repositories/server:/http/openSUSE_13.2/'
     - enabled: True
     - autorefresh: True
-    - gpgcheck: True
-    - gpgkey: 'http://download.opensuse.org/repositories/server:/http/openSUSE_13.2/repodata/repomd.xml.key'
+    - gpgcheck: {{ nginx.lookup.gpg_check }}
+    - gpgkey: {{ nginx.lookup.gpg_key }}
     - require_in:
       - pkg: nginx_install
     - watch_in:
@@ -63,7 +63,8 @@ nginx_yum_repo:
     {%- else %}
     - baseurl: 'http://nginx.org/packages/rhel/{{ nginx.lookup.rh_os_releasever }}/$basearch/'
     {%- endif %}
-    - gpgcheck: False
+    - gpgcheck: {{ nginx.lookup.gpg_check }}
+    - gpgkey: {{ nginx.lookup.gpg_key }}
     - enabled: True
     - require_in:
       - pkg: nginx_install

--- a/nginx/ng/map.jinja
+++ b/nginx/ng/map.jinja
@@ -26,6 +26,8 @@
             'vhost_use_symlink': False,
             'pid_file': '/run/nginx.pid',
             'rh_os_releasever': '$releasever',
+            'gpg_check': False,
+            'gpg_key': 'http://nginx.org/keys/nginx_signing.key',
         },
         'Suse': {
             'package': 'nginx',
@@ -36,6 +38,8 @@
             'vhost_enabled': '/etc/nginx/conf.d',
             'vhost_use_symlink': False,
             'pid_file': '/run/nginx.pid',
+            'gpg_check': True,
+            'gpg_key': 'http://download.opensuse.org/repositories/server:/http/openSUSE_13.2/repodata/repomd.xml.key'
         },
         'Arch': {
             'package': 'nginx',

--- a/pillar.example
+++ b/pillar.example
@@ -37,6 +37,8 @@ nginx:
       vhost_use_symlink: True
       # This is required for RedHat like distros (Amazon Linux) that don't follow semantic versioning for $releasever
       rh_os_releasever: '6'
+      # Currently it can be used on rhel/centos/suse when installing from repo
+      gpg_check: True
 
     # Source compilation is not currently a part of nginx.ng
     from_source: False


### PR DESCRIPTION
Added option to set gpgcheck and gpgkey via pillar on rhel/centos/suse.

Related to ticket #107