### PR TITLE
Fix ppa install for Debian

### DIFF
--- a/nginx/ng/install.sls
+++ b/nginx/ng/install.sls
@@ -38,7 +38,7 @@ nginx_ppa_repo:
     {% if salt['grains.get']('os') == 'Ubuntu' %}
     - ppa: nginx/{{ nginx.ppa_version }}
     {% else %}
-    - name: deb http://ppa.launchpad.net/nginx/{{ nginx.ppa_version }}/ubuntu lucid main
+    - name: deb http://ppa.launchpad.net/nginx/{{ nginx.ppa_version }}/ubuntu trusty main
     - keyid: C300EE8C
     - keyserver: keyserver.ubuntu.com
     {% endif %}

--- a/nginx/ng/install.sls
+++ b/nginx/ng/install.sls
@@ -35,7 +35,13 @@ nginx_ppa_repo:
     {%- else %}
     - absent
     {%- endif %}
+    {% if salt['grains.get']('os') == 'Ubuntu' %}
     - ppa: nginx/{{ nginx.ppa_version }}
+    {% else %}
+    - name: deb http://ppa.launchpad.net/nginx/{{ nginx.ppa_version }}/ubuntu lucid main
+    - keyid: C300EE8C
+    - keyserver: keyserver.ubuntu.com
+    {% endif %}
     - require_in:
       - pkg: nginx_install
     - watch_in:


### PR DESCRIPTION
On Ubuntu, you can take advantage of Personal Package Archives on Launchpad simply by specifying the user and archive name.  On other apt-based systems this must be the complete entry as it would be seen in the sources.list file.