### PR TITLE
Build from source with nginx.ng

### DIFF
--- a/nginx/ng/files/nginx.service
+++ b/nginx/ng/files/nginx.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=The NGINX HTTP and reverse proxy server
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=forking
+PIDFile=/run/nginx.pid
+ExecStartPre=/usr/sbin/nginx -t
+ExecStart=/usr/sbin/nginx
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s QUIT $MAINPID
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/nginx/ng/init.sls
+++ b/nginx/ng/init.sls
@@ -2,6 +2,8 @@
 #
 # Meta-state to fully install nginx.
 
+{% from 'nginx/ng/map.jinja' import nginx, sls_block with context %}
+
 include:
   - nginx.ng.config
   - nginx.ng.service
@@ -18,4 +20,8 @@ extend:
   nginx_config:
     file:
       - require:
+        {% if nginx.install_from_source %}
+        - cmd: nginx_install
+        {% else %}
         - pkg: nginx_install
+        {% endif %}

--- a/nginx/ng/install.sls
+++ b/nginx/ng/install.sls
@@ -4,14 +4,72 @@
 
 {% from 'nginx/ng/map.jinja' import nginx, sls_block with context %}
 
+{% if nginx.install_from_source %}
+nginx_build_dep:
+  {% if salt['grains.get']('os_family') == 'Debian' %}
+  cmd.run:
+    - name: apt-get -y build-dep nginx
+  {% elif salt['grains.get']('os_family') == 'RedHat' %}
+  cmd.run:
+    - name: yum-builddep -y nginx
+  {% else %}
+  ## install build deps for other distros
+  {% endif %}
+
+nginx_download:
+  archive.extracted:
+    - name: /tmp/
+    - source: http://nginx.org/download/nginx-{{ nginx.source_version }}.tar.gz
+    - source_hash: sha256={{ nginx.source_hash }}
+    - archive_format: tar
+    - if_missing: /usr/sbin/nginx-{{ nginx.source_version }}
+    - require:
+      - cmd: nginx_build_dep
+    - onchanges:
+      - cmd: nginx_build_dep
+
+nginx_configure:
+  cmd.run:
+    - name: ./configure --prefix=/etc/nginx --sbin-path=/usr/sbin/nginx --conf-path=/etc/nginx/nginx.conf {{ nginx.source.opts | join(' ') }}
+    - cwd: /tmp/nginx-{{ nginx.source_version }}
+    - require:
+      - archive: nginx_download
+    - onchanges:
+      - archive: nginx_download
+
+nginx_compile:
+  cmd.run:
+    - name: make
+    - cwd: /tmp/nginx-{{ nginx.source_version }}
+    - require:
+      - cmd: nginx_configure
+{% endif %}
+
 nginx_install:
   {% if nginx.install_from_source %}
-  ## add source compilation here
+  cmd.run:
+    - name: make install
+    - cwd: /tmp/nginx-{{ nginx.source_version }}
+    - require:
+      - cmd: nginx_compile
+    - onchanges:
+      - cmd: nginx_compile
   {% else %}
   pkg.installed:
     {{ sls_block(nginx.package.opts) }}
     - name: {{ nginx.lookup.package }}
   {% endif %}
+
+{% if nginx.install_from_source %}
+nginx_link:
+  file.copy:
+    - name: /usr/sbin/nginx-{{ nginx.source_version }}
+    - source: /usr/sbin/nginx
+    - require:
+      - cmd: nginx_install
+    - onchanges:
+      - cmd: nginx_install
+{% endif %}
 
 {% if salt['grains.get']('os_family') == 'Debian' %}
   {%- if nginx.install_from_repo %}

--- a/nginx/ng/map.jinja
+++ b/nginx/ng/map.jinja
@@ -77,6 +77,11 @@
     'install_from_ppa': False,
     'install_from_repo': False,
     'ppa_version': 'stable',
+    'source_version': '1.10.0',
+    'source_hash': '8ed647c3dd65bc4ced03b0e0f6bf9e633eff6b01bac772bcf97077d58bc2be4d',
+    'source': {
+        'opts': {},
+    },
     'package': {
         'opts': {},
     },

--- a/nginx/ng/service.sls
+++ b/nginx/ng/service.sls
@@ -7,6 +7,12 @@
 
 include:
   - nginx.ng.install
+
+{% if nginx.install_from_source %}
+/lib/systemd/system/nginx.service:
+  file.managed:
+    - source: salt://nginx/ng/files/nginx.service
+{% endif %} 
   
 nginx_service:
   service.{{ service_function }}:
@@ -16,6 +22,8 @@ nginx_service:
     - require:
       - sls: nginx.ng.install
     - watch:
-      {% if not nginx.install_from_source %}
+      {% if nginx.install_from_source %}
+      - cmd: nginx_install
+      {% else %}
       - pkg: nginx_install
       {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -21,10 +21,14 @@ nginx:
 
 nginx:
   ng:
-    # PPA installing
+    # PPA install
     install_from_ppa: True
     # Set to 'stable', 'development' (mainline), 'community', or 'nightly' for each build accordingly ( https://launchpad.net/~nginx )
     ppa_version: 'stable'
+
+    # Source install
+    source_version: '1.10.0'
+    source_hash: ''
     
     # These are usually set by grains in map.jinja
     lookup:
@@ -42,6 +46,9 @@ nginx:
 
     # Source compilation is not currently a part of nginx.ng
     from_source: False
+
+    source:
+      opts: {}
 
     package:
       opts: {} # this partially exposes parameters of pkg.installed


### PR DESCRIPTION
Build NGINX from source with nginx.ng state with support for passing
compile time flags necessary for installing modules such as more headers
by the openresty project.