### PR TITLE
Update config.sls to disable sorting

### DIFF
--- a/nginx/ng/config.sls
+++ b/nginx/ng/config.sls
@@ -19,4 +19,4 @@ nginx_config:
     - source: salt://nginx/ng/files/nginx.conf
     - template: jinja
     - context:
-        config: {{ nginx.server.config|json() }}
+        config: {{ nginx.server.config|json(sort_keys=False) }}


### PR DESCRIPTION
Adding sort_keys=False to json() allows nginx.server.config to be sorted as needed for the resulting config file to work with access_log+log_format (issue #102 ) and other parameters (issue #40)