### PR TITLE
Add the possiblity to define vhosts configs as key/value pairs.

### DIFF
--- a/nginx/ng/files/vhost.conf
+++ b/nginx/ng/files/vhost.conf
@@ -4,17 +4,29 @@
         {%- if value is number or value is string -%}
 {{ lb }}{{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
         {%- elif value is mapping -%}
-            {%- for k, v in value.items() -%}
-                {%- if v is number or v is string -%}
-{{ vhost_config([v], k, ind) }}
-                {%- elif v|length() > 0 and (v[0] is number or v[0] is string) -%}
-{{ lb }}{{ k|indent(ind,True) }}{{ vhost_config(v,'', 0, '', '')}}{{ delim }}
+            {%- if 'key' in value and 'value' in value -%}
+                {%- if value.value is number or value.value is string -%}
+{{ vhost_config([value.value], value.key, ind) }}
+                {%- elif value.value|length() > 0 and (value.value[0] is number or value.value[0] is string) -%}
+{{ lb }}{{ value.key|indent(ind,True) }}{{ vhost_config(value.value,'', 0, '', '')}}{{ delim }}
                 {%- else %}
+{{ lb }}{{ value.key|indent(ind, True) }} {{ '{' }}
+{{- vhost_config(value.value, '', ind + ind_increment) }}
+{{ '}'|indent(ind, True) }}
+                {%- endif -%}
+            {%- else -%}
+                {%- for k, v in value.items() -%}
+                    {%- if v is number or v is string -%}
+{{ vhost_config([v], k, ind) }}
+                    {%- elif v|length() > 0 and (v[0] is number or v[0] is string) -%}
+{{ lb }}{{ k|indent(ind,True) }}{{ vhost_config(v,'', 0, '', '')}}{{ delim }}
+                    {%- else %}
 {{ lb }}{{ k|indent(ind, True) }} {{ '{' }}
 {{- vhost_config(v, '', ind + ind_increment) }}
 {{ '}'|indent(ind, True) }}
-                {%- endif -%}
-            {%- endfor -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
         {%- elif value is iterable -%}
 {{ vhost_config(value, ind + ind_increment, delim, operator) }}
         {%- endif -%}

--- a/nginx/ng/vhosts_config.sls
+++ b/nginx/ng/vhosts_config.sls
@@ -84,7 +84,7 @@ nginx_vhost_available_dir:
 
 # Managed enabled/disabled state for vhosts
 {% for vhost, settings in nginx.vhosts.managed.items() %}
-{% if settings.config != None %}
+{% if settings.get('config', False) %}
 {% set conf_state_id = 'vhost_conf_' ~ loop.index0 %}
 {{ conf_state_id }}:
   file.managed:
@@ -101,7 +101,7 @@ nginx_vhost_available_dir:
 {% do vhost_states.append(conf_state_id) %}
 {% endif %}
 
-{% if settings.enabled != None %}
+{% if settings.get('config', False) %}
 {% set status_state_id = 'vhost_state_' ~ loop.index0 %}
 {{ status_state_id }}:
 {{ manage_status(vhost, settings.enabled) }}

--- a/pillar.example
+++ b/pillar.example
@@ -29,7 +29,7 @@ nginx:
     # Source install
     source_version: '1.10.0'
     source_hash: ''
-    
+
     # These are usually set by grains in map.jinja
     lookup:
       package: nginx-custom
@@ -62,7 +62,7 @@ nginx:
 
       # nginx.conf (main server) declarations
       # dictionaries map to blocks {} and lists cause the same declaration to repeat with different values
-      config: 
+      config:
         worker_processes: 4
         pid: /run/nginx.pid
         events:
@@ -91,14 +91,14 @@ nginx:
           disabled_name: mysite.aint_on # an alternative disabled name to be use when not symlinking
           enabled: True
           overwrite: True # overwrite an existing vhost file or not
-          
+
           # May be a list of config options or None, if None, no vhost file will be managed/templated
           # Take server directives as lists of dictionaries. If the dictionary value is another list of
           # dictionaries a block {} will be started with the dictionary key name
           config:
             - server:
               - server_name: localhost
-              - listen: 
+              - listen:
                 - 80
                 - default_server
               - index:
@@ -109,7 +109,7 @@ nginx:
                   - $uri
                   - $uri/ =404
                 - test: something else
-                
+
           # The above outputs:
           # server {
           #    server_name localhost;
@@ -119,7 +119,33 @@ nginx:
           #        try_files $uri $uri/ =404;
           #        test something else;
           #    }
-          # }         
+          # }
+
+        # You can also give these parameters as key/value pairs,
+        # this is usefull for the ext_pillar.mongo for example.
+
+        mysite2:
+          config:
+            - key: server_name
+              value: localhost2
+            - key: listen
+              value:
+                - 80
+                - default_server
+            - key: index
+              value:
+                - index.html
+                - index.htm
+            - key: location ~ .htm
+              value:
+                - key: try_files
+                  value:
+                  - $uri
+                  - $uri/ =404
+                - key: test
+                  value: something else
+
+        # This will output the same as the above example.
 
     # If you're doing SSL termination, you can deploy certificates this way.
     # The private one(s) should go in a separate pillar file not in version


### PR DESCRIPTION
With this PR you can also give these parameters as key/value pairs,
this is usefull for the ext_pillar.mongo for example where BSON doesn't allow "." in field names.

```
mysite:
  config:
    - key: server_name
      value: localhost
    - key: listen
      value:
        - 80
        - default_server
    - key: index
      value:
        - index.html
        - index.htm
    - key: location ~ .htm
      value:
        - key: try_files
          value:
          - $uri
          - $uri/ =404
        - key: test
          value: something else
```

This will output the same as the example in pillar.example:

```
      # The above outputs:
      # server {
      #    server_name localhost;
      #    listen 80 default_server;
      #    index index.html index.htm;
      #    location ~ .htm {
      #        try_files $uri $uri/ =404;
      #        test something else;
      #    }
      # }
```

Signed-off-by: Rene Jochum rene@jochums.at
