### PR TITLE
nginx/package: add onlyif requisite to nginx-old-init

### DIFF
--- a/nginx/package.sls
+++ b/nginx/package.sls
@@ -28,6 +28,7 @@ nginx-old-init:
       - file: nginx-old-init
     - require_in:
       - file: nginx
+    - onlyif: [ -e /var/run/nginx.pid ]
 
 # RedHat requires the init file in place to chkconfig off
 {% if nginx['disable_before_rename'] %}


### PR DESCRIPTION
A requisite should be used so that we are only issuing a kill when there is an available pid to pull from. This will allow us to avoid these types of failures:

```
          ID: nginx-old-init
    Function: module.wait
        Name: cmd.run
      Result: True
     Comment: Module function cmd.run executed
     Started: 21:47:27.460102
    Duration: 5.6 ms
     Changes:   
              ----------
              ret:
                  cat: /var/run/nginx.pid: No such file or directory
                  sh: 1: kill: Usage: kill [-s sigspec | -signum | -sigspec] [pid | job]... or
                  kill -l [exitstatus]
```

With this commit the state proceeds cleanly.

```
          ID: nginx-old-init
    Function: module.wait
        Name: cmd.run
      Result: True
     Comment: onlyif execution failed
     Started: 21:49:15.761865
    Duration: 39.185 ms
     Changes:   
```