### PR TITLE
Use oscodename instead of hard coded trusty for deb

### DIFF
--- a/nginx/ng/pkg.sls
+++ b/nginx/ng/pkg.sls
@@ -35,7 +35,6 @@ nginx_ppa_repo:
     - ppa: nginx/{{ nginx.ppa_version }}
     {% else %}
     - name: deb http://ppa.launchpad.net/nginx/{{ nginx.ppa_version }}/ubuntu {{ grains['oscodename'] }} main
-    #- name: deb http://ppa.launchpad.net/nginx/{{ nginx.ppa_version }}/ubuntu trusty main
     - keyid: C300EE8C
     - keyserver: keyserver.ubuntu.com
     {% endif %}

--- a/nginx/ng/pkg.sls
+++ b/nginx/ng/pkg.sls
@@ -34,7 +34,8 @@ nginx_ppa_repo:
     {% if salt['grains.get']('os') == 'Ubuntu' %}
     - ppa: nginx/{{ nginx.ppa_version }}
     {% else %}
-    - name: deb http://ppa.launchpad.net/nginx/{{ nginx.ppa_version }}/ubuntu trusty main
+    - name: deb http://ppa.launchpad.net/nginx/{{ nginx.ppa_version }}/ubuntu {{ grains['oscodename'] }} main
+    #- name: deb http://ppa.launchpad.net/nginx/{{ nginx.ppa_version }}/ubuntu trusty main
     - keyid: C300EE8C
     - keyserver: keyserver.ubuntu.com
     {% endif %}


### PR DESCRIPTION
It would be better to install from the os repository instead of hard coding to trusty