### PR TITLE
Disabled automatic sorting of mapping keys in jinja templating

### DIFF
--- a/nginx/ng/config.sls
+++ b/nginx/ng/config.sls
@@ -19,4 +19,4 @@ nginx_config:
     - source: salt://nginx/ng/files/nginx.conf
     - template: jinja
     - context:
-        config: {{ nginx.server.config|json() }}
+        config: {{ nginx.server.config|json(sort_keys=False) }}

--- a/nginx/ng/map.jinja
+++ b/nginx/ng/map.jinja
@@ -1,6 +1,6 @@
 {% macro sls_block(dict) %}
     {% for key, value in dict.items() %}
-    - {{ key }}: {{ value|json() }}
+    - {{ key }}: {{ value|json(sort_keys=False) }}
     {% endfor %}
 {% endmacro %}
 

--- a/nginx/ng/servers_config.sls
+++ b/nginx/ng/servers_config.sls
@@ -93,7 +93,7 @@ nginx_server_available_dir:
     - source: salt://nginx/ng/files/server.conf
     - template: jinja
     - context:
-        config: {{ settings.config|json() }}
+        config: {{ settings.config|json(sort_keys=False) }}
     {% if 'overwrite' in settings and settings.overwrite == False %}
     - unless:
       - test -e {{ server_curpath(server) }}


### PR DESCRIPTION
The way the `json()` filter is used makes any attempt to force a particular order to nginx configuration contexts difficult. The `sort_keys` parameter seems to be well supported and shouldn't do any harm, while making it easier to obtain a predictable configuration.