### PR TITLE
Fixed reference to pkg state when installing from official Debian repo

### DIFF
--- a/nginx/ng/pkg.sls
+++ b/nginx/ng/pkg.sls
@@ -20,9 +20,9 @@ nginx-official-repo:
     - keyid: ABF5BD827BD9BF62
     - keyserver: keyserver.ubuntu.com
     - require_in:
-      - pkg: nginx
+      - pkg: nginx_install
     - watch_in:
-      - pkg: nginx
+      - pkg: nginx_install
   {%- else %}
 nginx_ppa_repo:
   pkgrepo:


### PR DESCRIPTION
Hey all,

When installing from the official repository on Debian Jessie I got the following error:
```
local:
    Data failed to compile:
----------
    Cannot extend ID 'nginx' in 'base:nginx.ng.pkg'. It is not part of the high state.
This is likely due to a missing include statement or an incorrectly typed ID.
Ensure that a state with an ID of 'nginx' is available
in environment 'base' and to SLS 'nginx.ng.pkg'
```

This is the package name I had in the pillar:
```
# salt-call pillar.item nginx:ng:lookup:package
local:
    ----------
    nginx:ng:lookup:package:
        nginx-full
```

I found out that the `pkg` state was looking for the fixed name *nginx* when using the official Debian repository instead of the *nginx_install* name as it was done for the Ubuntu repository. This PR fixes this problem.