### PR TITLE
Fix multiple values for the same key (include/listen) in server config file

### DIFF
--- a/nginx/ng/files/server.conf
+++ b/nginx/ng/files/server.conf
@@ -2,17 +2,17 @@
 {%- macro server_config(values, key='', ind=0, lb='\n', delim=';', operator=' ') -%}
     {%- for value in values -%}
         {%- if value is number or value is string -%}
-{{ lb }}{{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}
+{{ key|indent(ind, True) }}{{ operator }}{{ value }}{{ delim }}{{ lb }}
         {%- elif value is mapping -%}
             {%- for k, v in value.items() -%}
                 {%- if v is number or v is string -%}
 {{ server_config([v], k, ind) }}
                 {%- elif v|length() > 0 and (v[0] is number or v[0] is string) -%}
-{{ lb }}{{ k|indent(ind,True) }}{{ server_config(v,'', 0, '', '')}}{{ delim }}
-                {%- else %}
+{{ server_config(v, k, ind) }}
+                {%- else -%}
 {{ lb }}{{ k|indent(ind, True) }} {{ '{' }}
-{{- server_config(v, '', ind + ind_increment) }}
-{{ '}'|indent(ind, True) }}
+{{ server_config(v, '', ind + ind_increment) -}}
+{{ '}'|indent(ind, True) }}{{ lb }}
                 {%- endif -%}
             {%- endfor -%}
         {%- elif value is iterable -%}

--- a/pillar.example
+++ b/pillar.example
@@ -201,28 +201,40 @@ nginx:
             - server:
               - server_name: localhost
               - listen:
-                - 80
-                - default_server
-              - index:
-                - index.html
-                - index.htm
+                - '80 default_server'
+              - listen:
+                - '443 ssl'
+              - index: 'index.html index.htm'
               - location ~ .htm:
-                - try_files:
-                  - $uri
-                  - $uri/ =404
+                - try_files: '$uri $uri/ =404'
                 - test: something else
               - include 'snippets/letsencrypt.conf'
 
-          # The above outputs:
+          # Or a slightly more compact alternative syntax:
+
+            - server:
+              - server_name: localhost
+              - listen:
+                - '80 default_server'
+                - '443 ssl'
+              - index: 'index.html index.htm'
+              - location ~ .htm:
+                - try_files: '$uri $uri/ =404'
+                - test: something else
+              - include 'snippets/letsencrypt.conf'
+
+          # both of those output:
           # server {
           #    server_name localhost;
           #    listen 80 default_server;
+          #    listen 443 ssl;
           #    index index.html index.htm;
           #    location ~ .htm {
           #        try_files $uri $uri/ =404;
           #        test something else;
           #    }
           # }
+
         mysite2: # Using source_path options to upload the file instead of templating all the file
           enabled: True
           available_dir: /etc/nginx/sites-available


### PR DESCRIPTION
With this one can now also write

```
 - include:
   - file1
   - file2
```
rather than only
```
 - include: file1
 - include: file2
```

Both would be rendered the same.