### PR TITLE
Move includes to the top of nginx.conf

### DIFF
--- a/nginx/ng/files/nginx.conf
+++ b/nginx/ng/files/nginx.conf
@@ -32,6 +32,10 @@
 #
 # This file is managed by Salt.
 
+{% if 'include' in config.keys() %}
+{{ nginx_block(config.pop('include'), 'include') }}
+{%- endif -%}
+
 {% for key, value in config.items() %}
 {{ nginx_block(value, key) }}
 {%- endfor -%}


### PR DESCRIPTION
With this change it is possible to add

```yaml
nginx:
  ng:
    server:
      config:
        include: /etc/nginx/modules-enabled/*.conf
```

to the pillar, which fixes the problem from #151. Without this change this would result in
```
nginx: [emerg] "load_module" directive is specified too late
```