### PR TITLE
Add support to install phusion passenger in the `ng`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,3 +98,12 @@ and does not bind them to service calls.
 -------------------
 
 Manages nginx virtual hosts files and binds them to service calls.
+
+``nginx.ng.passenger``
+----------------------
+
+Installs and configures Phusion Passenger module for nginx. You need to enable
+the upstream phusion passenger repository with `install_from_phusionpassenger: true`. 
+Nginx will also be installed from that repository, as it needs to be modified to
+allow the passenger module to work. 
+

--- a/nginx/ng/map.jinja
+++ b/nginx/ng/map.jinja
@@ -8,6 +8,7 @@
     'lookup': salt['grains.filter_by']({
         'Debian': {
             'package': 'nginx',
+            'passenger_package': 'passenger',
             'service': 'nginx',
             'webuser': 'www-data',
             'conf_file': '/etc/nginx/nginx.conf',
@@ -18,6 +19,7 @@
         },
         'CentOS': {
             'package': 'nginx',
+            'passenger_package': 'passenger',
             'service': 'nginx',
             'webuser': 'nginx',
             'conf_file': '/etc/nginx/nginx.conf',
@@ -31,6 +33,7 @@
         },
         'RedHat': {
             'package': 'nginx',
+            'passenger_package': 'passenger',
             'service': 'nginx',
             'webuser': 'nginx',
             'conf_file': '/etc/nginx/nginx.conf',
@@ -41,6 +44,11 @@
             'rh_os_releasever': '$releasever',
             'gpg_check': False,
             'gpg_key': 'http://nginx.org/keys/nginx_signing.key',
+            'passenger': {
+              'passenger_root': '/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini',
+              'passenger_instance_registry_dir': ' /var/run/passenger-instreg',
+              'passenger_ruby': '/usr/bin/ruby',
+            },
         },
         'Suse': {
             'package': 'nginx',
@@ -76,6 +84,7 @@
     'install_from_source': False,
     'install_from_ppa': False,
     'install_from_repo': False,
+    'install_from_phusionpassenger': False,
     'ppa_version': 'stable',
     'source_version': '1.10.0',
     'source_hash': '8ed647c3dd65bc4ced03b0e0f6bf9e633eff6b01bac772bcf97077d58bc2be4d',
@@ -125,6 +134,10 @@
         },
         'managed': {},
     },
+    'passenger': {
+        'passenger_root': '/usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini',
+        'passenger_ruby': '/usr/bin/ruby',
+    },
 }, merge=True) %}
 
 {% if 'user' not in nginx.server.config %}
@@ -139,3 +152,17 @@
 })%}
 {% endif %}
 
+{% if salt['grains.get']('os_family') == 'RedHat' %}
+{% do nginx.passenger.update({
+    'passenger_root': '/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini',
+    'passenger_instance_registry_dir': '/var/run/passenger-instreg',
+})%}
+    {% if salt['grains.get']('osfinger') == 'CentOS-6' %}
+    {% do nginx.server.config.update({
+        'pid': '/var/run/nginx.pid',
+    })%}
+    {% do nginx.passenger.update({
+        'passenger_root': '/usr/lib/ruby/1.8/phusion_passenger/locations.ini',
+    })%}
+    {% endif %}
+{% endif %}

--- a/nginx/ng/passenger.sls
+++ b/nginx/ng/passenger.sls
@@ -1,0 +1,41 @@
+# nginx.ng.passenger
+#
+# Manages installation of passenger from repo.
+# Requires install_from_phusionpassenger = True
+
+{% from 'nginx/ng/map.jinja' import nginx, sls_block with context %}
+
+{% if salt['grains.get']('os_family') in ['Debian', 'RedHat'] %}
+include:
+  - nginx.ng.pkg
+  - nginx.ng.service
+
+passenger_install:
+  pkg.installed:
+    - name: {{ nginx.lookup.passenger_package }}
+    - require:
+      - pkg: nginx_install
+    - require_in:
+      - service: nginx_service
+
+/etc/nginx/passenger.conf:
+  file.absent:
+    - require:
+      - pkg: passenger_install
+
+passenger_config:
+  file.managed:
+    {{ sls_block(nginx.server.opts) }}
+    - name: /etc/nginx/conf.d/passenger.conf
+    - source: salt://nginx/ng/files/nginx.conf
+    - template: jinja
+    - context:
+      config: {{ nginx.passenger|json() }}
+    - watch_in:
+      - service: nginx_service
+    - require_in:
+      - service: nginx_service
+    - require:
+      - file: /etc/nginx/passenger.conf
+      - pkg: passenger_install
+{% endif %}

--- a/nginx/ng/pkg.sls
+++ b/nginx/ng/pkg.sls
@@ -3,6 +3,19 @@
 # Manages installation of nginx from pkg.
 
 {% from 'nginx/ng/map.jinja' import nginx, sls_block with context %}
+{%- if nginx.install_from_repo %}
+  {% set from_official = true %}
+  {% set from_ppa = false %}
+  {% set from_phusionpassenger = false %}
+{% elif nginx.install_from_ppa %}
+  {% set from_official = false %}
+  {% set from_ppa = true %}
+  {% set from_phusionpassenger = false %}
+{% elif nginx.install_from_phusionpassenger %}
+  {% set from_official = false %}
+  {% set from_ppa = false %}
+  {% set from_phusionpassenger = true %}
+{%- endif %}
 
 nginx_install:
   pkg.installed:
@@ -10,10 +23,13 @@ nginx_install:
     - name: {{ nginx.lookup.package }}
 
 {% if salt['grains.get']('os_family') == 'Debian' %}
-  {%- if nginx.install_from_repo %}
-nginx-official-repo:
+nginx_official_repo:
   pkgrepo:
+    {%- if from_official %}
     - managed
+    {%- else %}
+    - absent
+    {%- endif %}
     - humanname: nginx apt repo
     - name: deb http://nginx.org/packages/{{ grains['os'].lower() }}/ {{ grains['oscodename'] }} nginx
     - file: /etc/apt/sources.list.d/nginx-official-{{ grains['oscodename'] }}.list
@@ -23,10 +39,10 @@ nginx-official-repo:
       - pkg: nginx_install
     - watch_in:
       - pkg: nginx_install
-  {%- else %}
+
 nginx_ppa_repo:
   pkgrepo:
-    {%- if nginx.install_from_ppa %}
+    {%- if from_ppa %}
     - managed
     {%- else %}
     - absent
@@ -42,13 +58,29 @@ nginx_ppa_repo:
       - pkg: nginx_install
     - watch_in:
       - pkg: nginx_install
-  {%- endif %}
+
+nginx_phusionpassenger_repo:
+  pkgrepo:
+    {%- if from_phusionpassenger %}
+    - managed
+    {%- else %}
+    - absent
+    {%- endif %}
+    - humanname: nginx phusionpassenger repo
+    - name: deb https://oss-binaries.phusionpassenger.com/apt/passenger {{ grains['oscodename'] }} main
+    - file: /etc/apt/sources.list.d/nginx-phusionpassenger-{{ grains['oscodename'] }}.list
+    - keyid: 561F9B9CAC40B2F7
+    - keyserver: keyserver.ubuntu.com
+    - require_in:
+      - pkg: nginx_install
+    - watch_in:
+      - pkg: nginx_install
 {% endif %}
 
 {% if salt['grains.get']('os_family') == 'Suse' %}
 nginx_zypp_repo:
   pkgrepo:
-    {%- if nginx.install_from_repo %}
+    {%- if from_official %}
     - managed
     {%- else %}
     - absent
@@ -68,11 +100,12 @@ nginx_zypp_repo:
 
 {% if salt['grains.get']('os_family') == 'RedHat' %}
 nginx_yum_repo:
-  {%- if nginx.install_from_repo %}
-  pkgrepo.managed:
-  {%- else %}
-  pkgrepo.absent:
-  {%- endif %}
+  pkgrepo:
+    {%- if from_official %}
+    - managed
+    {%- else %}
+    - absent
+    {%- endif %}
     - name: nginx
     - humanname: nginx repo
     {%- if salt['grains.get']('os') == 'CentOS' %}
@@ -83,6 +116,27 @@ nginx_yum_repo:
     - gpgcheck: {{ nginx.lookup.gpg_check }}
     - gpgkey: {{ nginx.lookup.gpg_key }}
     - enabled: True
+    - require_in:
+      - pkg: nginx_install
+    - watch_in:
+      - pkg: nginx_install
+
+nginx_phusionpassenger_yum_repo:
+  pkgrepo:
+    {%- if from_phusionpassenger %}
+    - managed
+    {%- else %}
+    - absent
+    {%- endif %}
+    - name: passenger
+    - humanname: nginx phusionpassenger repo
+    - baseurl: 'https://oss-binaries.phusionpassenger.com/yum/passenger/el/$releasever/$basearch'
+    - repo_gpgcheck: 1
+    - gpgcheck: 0 
+    - gpgkey: 'https://packagecloud.io/gpg.key'
+    - enabled: True
+    - sslverify: 1
+    - sslcacert: /etc/pki/tls/certs/ca-bundle.crt
     - require_in:
       - pkg: nginx_install
     - watch_in:

--- a/pillar.example
+++ b/pillar.example
@@ -21,8 +21,19 @@ nginx:
 
 nginx:
   ng:
+    # The following three `install_from_` options are mutually exclusive. If none is used, the distro's provided
+    # package will be installed. If one of the `install_from` option is set to `True`, the state will
+    # make sure the other two repos are removed.
+
+    # Use the official's nginx repo binaries
+    install_from_repo: false
+
+    # Use Phusionpassenger's repo to install nginx and passenger binaries
+    # Debian, Centos, Ubuntu and Redhat are currently available
+    install_from_phusionpassenger: false
+
     # PPA install
-    install_from_ppa: True
+    install_from_ppa: false
     # Set to 'stable', 'development' (mainline), 'community', or 'nightly' for each build accordingly ( https://launchpad.net/~nginx )
     ppa_version: 'stable'
 
@@ -140,3 +151,12 @@ nginx:
           -----BEGIN RSA PRIVATE KEY-----
           (Your Private Key: www.example.com.key)
           -----END RSA PRIVATE KEY-----
+
+    # Passenger configuration
+    # Default passenger configuration is provided, and will be deployed in
+    # /etc/nginx/conf.d/passenger.conf
+    passenger:
+      passenger_root: /usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini
+      passenger_ruby: /usr/bin/ruby
+      passenger_instance_registry_dir: /var/run/passenger-instreg
+


### PR DESCRIPTION
This PR adds a state to install Phusion passenger module from its repository.

Organized the `nginx.ng.pkg.sls` file so, when a repo is enabled the other two are disabled to avoid conflicting versions and packages.