### PR TITLE
Fix missing defaults when no `install_from_*` is set

### DIFF
--- a/nginx/ng/pkg.sls
+++ b/nginx/ng/pkg.sls
@@ -15,6 +15,10 @@
   {% set from_official = false %}
   {% set from_ppa = false %}
   {% set from_phusionpassenger = true %}
+{% else %}
+  {% set from_official = false %}
+  {% set from_ppa = false %}
+  {% set from_phusionpassenger = false %}
 {%- endif %}
 
 nginx_install:


### PR DESCRIPTION
Fixes #159 
Tested on debian/jessie64, centos/6, centos/7, ubuntu/xenial (16.04)