### PR TITLE
Fix for OpenSuse leap, salt 2016.3.4-84.13

### DIFF
--- a/nginx/ng/pkg.sls
+++ b/nginx/ng/pkg.sls
@@ -81,7 +81,7 @@ nginx_phusionpassenger_repo:
       - pkg: nginx_install
 {% endif %}
 
-{% if salt['grains.get']('os_family') == 'Suse' %}
+{% if salt['grains.get']('os_family') == 'Suse' or salt['grains.get']('os') == 'SUSE' %}
 nginx_zypp_repo:
   pkgrepo:
     {%- if from_official %}


### PR DESCRIPTION
PR to workaround salt bug: https://github.com/saltstack/salt/issues/39953

- nginx failed to start on opensuse LEAP as Salt 2016.3.4 configured wrong username because following logic returned false for nginx.ng.pkg state-

`-{% if salt['grains.get']('os_family') == 'Suse' %}`

Verified solution.

`{% if salt['grains.get']('os_family') == 'Suse' or salt['grains.get']('os') == 'SUSE' %}`

