### PR TITLE
Updated pillar.example file with distro learnings

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,19 +1,19 @@
 # nginx:
- #  install_from_source: True
- #  use_upstart: True
- #  use_sysvinit: False
- #  user_auth_enabled: True
- #  with_luajit: False
- #  with_openresty: True
- #  repo_version: development  # Must be using ppa install by setting `repo_source = ppa`
- #  set_real_ips: # NOTE: to use this, nginx must have http_realip module enabled
- #    from_ips:
- #      - 10.10.10.0/24
- #    real_ip_header: X-Forwarded-For
- #  modules:
- #    headers-more:
- #      source: http://github.com/agentzh/headers-more-nginx-module/tarball/v0.21
- #      source_hash: sha1=dbf914cbf3f7b6cb7e033fa7b7c49e2f8879113b
+   install_from_source: True
+   use_upstart: True
+   use_sysvinit: False
+   user_auth_enabled: True
+   with_luajit: False
+   with_openresty: True
+   repo_version: development  # Must be using ppa install by setting `repo_source = ppa`
+   set_real_ips: # NOTE: to use this, nginx must have http_realip module enabled
+     from_ips:
+       - 10.10.10.0/24
+     real_ip_header: X-Forwarded-For
+   modules:
+     headers-more:
+       source: http://github.com/agentzh/headers-more-nginx-module/tarball/v0.21
+       source_hash: sha1=dbf914cbf3f7b6cb7e033fa7b7c49e2f8879113b
 
 # ========
 # nginx.ng
@@ -42,18 +42,19 @@ nginx:
     source_hash: ''
     
     # These are usually set by grains in map.jinja
+    # Typically you can comment these out.
     lookup:
-      # package: nginx-custom
-      # service: nginx
-      # webuser: www-data
-      # conf_file: /etc/nginx/nginx.conf
-      # server_available: /etc/nginx/sites-available
-      # server_enabled: /etc/nginx/sites-enabled
-      # server_use_symlink: True
+      package: nginx-custom
+      service: nginx
+      webuser: www-data
+      conf_file: /etc/nginx/nginx.conf
+      server_available: /etc/nginx/sites-available
+      server_enabled: /etc/nginx/sites-enabled
+      server_use_symlink: True
       # This is required for RedHat like distros (Amazon Linux) that don't follow semantic versioning for $releasever
-      # rh_os_releasever: '6'
+      rh_os_releasever: '6'
       # Currently it can be used on rhel/centos/suse when installing from repo
-      # gpg_check: True
+      gpg_check: True
       pid_file: /var/run/nginx.pid   ### Prevent Rendering SLS error (map.jinja:149) if nginx.server.config.pid undefined (Ubuntu, etc) ###
       
 
@@ -102,7 +103,7 @@ nginx:
           # may be True, False, or None where True is enabled, False, disabled, and None indicates no action
           enabled: True
           ########### 
-          ## PLEASE MODIFY 'available_dir' AND 'enabled_dir' VALUES TO ALTERNATIVE VALUES ##
+          ## Modify  'available_dir' AND 'enabled_dir' '/etc/nginx' location to alternative value.
           ###########
           available_dir: /etc/nginx/sites-available # an alternate directory (not sites-available) where this server may be found
           enabled_dir: /etc/nginx/sites-enabled # an alternate directory (not sites-enabled) where this server may be found

--- a/pillar.example
+++ b/pillar.example
@@ -1,19 +1,19 @@
-nginx:
-  install_from_source: True
-  use_upstart: True
-  use_sysvinit: False
-  user_auth_enabled: True
-  with_luajit: False
-  with_openresty: True
-  repo_version: development  # Must be using ppa install by setting `repo_source = ppa`
-  set_real_ips: # NOTE: to use this, nginx must have http_realip module enabled
-    from_ips:
-      - 10.10.10.0/24
-    real_ip_header: X-Forwarded-For
-  modules:
-    headers-more:
-      source: http://github.com/agentzh/headers-more-nginx-module/tarball/v0.21
-      source_hash: sha1=dbf914cbf3f7b6cb7e033fa7b7c49e2f8879113b
+# nginx:
+ #  install_from_source: True
+ #  use_upstart: True
+ #  use_sysvinit: False
+ #  user_auth_enabled: True
+ #  with_luajit: False
+ #  with_openresty: True
+ #  repo_version: development  # Must be using ppa install by setting `repo_source = ppa`
+ #  set_real_ips: # NOTE: to use this, nginx must have http_realip module enabled
+ #    from_ips:
+ #      - 10.10.10.0/24
+ #    real_ip_header: X-Forwarded-For
+ #  modules:
+ #    headers-more:
+ #      source: http://github.com/agentzh/headers-more-nginx-module/tarball/v0.21
+ #      source_hash: sha1=dbf914cbf3f7b6cb7e033fa7b7c49e2f8879113b
 
 # ========
 # nginx.ng
@@ -43,17 +43,19 @@ nginx:
     
     # These are usually set by grains in map.jinja
     lookup:
-      package: nginx-custom
-      service: nginx
-      webuser: www-data
-      conf_file: /etc/nginx/nginx.conf
-      server_available: /etc/nginx/sites-available
-      server_enabled: /etc/nginx/sites-enabled
-      server_use_symlink: True
+      # package: nginx-custom
+      # service: nginx
+      # webuser: www-data
+      # conf_file: /etc/nginx/nginx.conf
+      # server_available: /etc/nginx/sites-available
+      # server_enabled: /etc/nginx/sites-enabled
+      # server_use_symlink: True
       # This is required for RedHat like distros (Amazon Linux) that don't follow semantic versioning for $releasever
-      rh_os_releasever: '6'
+      # rh_os_releasever: '6'
       # Currently it can be used on rhel/centos/suse when installing from repo
-      gpg_check: True
+      # gpg_check: True
+      pid_file: /var/run/nginx.pid   ### Prevent Rendering SLS error (map.jinja:149) if nginx.server.config.pid undefined (Ubuntu, etc) ###
+      
 
     # Source compilation is not currently a part of nginx.ng
     from_source: False
@@ -75,12 +77,13 @@ nginx:
       # dictionaries map to blocks {} and lists cause the same declaration to repeat with different values
       config: 
         worker_processes: 4
-        pid: /run/nginx.pid
+        pid: /var/run/nginx.pid		### Directory location must exist
         events:
           worker_connections: 768
         http:
           sendfile: 'on'
           include:
+            #### Note: Syntax issues in these files generate nginx [emerg] errors on startup.  ####
             - /etc/nginx/mime.types
             - /etc/nginx/conf.d/*.conf
             - /etc/nginx/sites-enabled/*
@@ -97,10 +100,13 @@ nginx:
       managed:
         mysite: # relative pathname of the server file
           # may be True, False, or None where True is enabled, False, disabled, and None indicates no action
-          available_dir: /tmp/sites-available # an alternate directory (not sites-available) where this server may be found
-          enabled_dir: /tmp/sites-enabled # an alternate directory (not sites-enabled) where this server may be found
-          disabled_name: mysite.aint_on # an alternative disabled name to be use when not symlinking
           enabled: True
+          ########### 
+          ## PLEASE MODIFY 'available_dir' AND 'enabled_dir' VALUES TO ALTERNATIVE VALUES ##
+          ###########
+          available_dir: /etc/nginx/sites-available # an alternate directory (not sites-available) where this server may be found
+          enabled_dir: /etc/nginx/sites-enabled # an alternate directory (not sites-enabled) where this server may be found
+          disabled_name: mysite.aint_on # an alternative disabled name to be use when not symlinking
           overwrite: True # overwrite an existing server file or not
           
           # May be a list of config options or None, if None, no server file will be managed/templated


### PR DESCRIPTION
This PR updates the pillar.example file with my learnings from setting the pillars on three distributions, OpenSUSE (salt 2016.3), Ubuntu 17 (salt 2017.7.7), Fedora (salt 2016.11), using pillar.example as the starting point.  

The updated pillar.example removes issues below and newly commented stanzas points to fact the defaults in map.jinja are better.  IMHO, this is better pillar.example - but see also #132 

> nginx.ng.config 
> [ERROR] Rendering exception occurred: Jinja error: Undefined is not JSON serializable
>                       {{ sls_block(nginx.server.opts) }}
>                         ....
>                            config: {{ nginx.server.config|json() }}  <============
> 
> [ERROR] Rendering SLS base:nginx.ng.service failed. Jinja variable 'None' has no attribute 'service'
> 
> [ERROR] Rendering SLS base:nginx.ng.service failed. Jinja variable 'None' has no attribute 'server_enabled'
>                       nginx_server_enabled_dir:
>                              ....
>                           - name: {{ nginx.lookup.server_enabled }}      <============
> 
> Commenting 'nginx.server.config.pid' in pillar.example caused error in map.jinja (149).
> 
> The formula also fails because defaults /tmp/available_sites will never exist in default scenario.
> 
> Finally nginx would not start (on Ubuntu at least) complaining about [emerg] errors with following examples in pillar.example although this is not salt issue.
>        include
>         - /etc/nginx/mime.types
>         ..
>         - /etc/nginx/sites-enabled/*

