### PR TITLE
New feature - Enable the uploading of the config files

### DIFF
--- a/nginx/ng/config.sls
+++ b/nginx/ng/config.sls
@@ -12,7 +12,7 @@ nginx_log_dir:
     - group: {{ nginx.server.config.user }}
 {% endif %}
 
-{% if 'source' in nginx.server.config %}
+{% if 'source_path' in nginx.server.config %}
 {% set source_path = nginx.server.config.source %}
 {% else %} 
 {% set source_path = 'salt://nginx/ng/files/nginx.conf' %} 
@@ -23,7 +23,7 @@ nginx_config:
     - name: {{ nginx.lookup.conf_file }}
     - source: {{ source_path }}
     - template: jinja
-{% if 'source' not in nginx.server.config %} 
+{% if 'source_path' not in nginx.server.config %}
     - context:
         config: {{ nginx.server.config|json() }}
 {% endif %}

--- a/nginx/ng/config.sls
+++ b/nginx/ng/config.sls
@@ -13,7 +13,7 @@ nginx_log_dir:
 {% endif %}
 
 {% if 'source_path' in nginx.server.config %}
-{% set source_path = nginx.server.config.source %}
+{% set source_path = nginx.server.config.source_path %}
 {% else %} 
 {% set source_path = 'salt://nginx/ng/files/nginx.conf' %} 
 {% endif %}

--- a/nginx/ng/config.sls
+++ b/nginx/ng/config.sls
@@ -12,11 +12,18 @@ nginx_log_dir:
     - group: {{ nginx.server.config.user }}
 {% endif %}
 
+{% if 'source' in nginx.server.config %}
+{% set source_path = nginx.server.config.source %}
+{% else %} 
+{% set source_path = 'salt://nginx/ng/files/nginx.conf' %} 
+{% endif %}
 nginx_config:
   file.managed:
     {{ sls_block(nginx.server.opts) }}
     - name: {{ nginx.lookup.conf_file }}
-    - source: salt://nginx/ng/files/nginx.conf
+    - source: {{ source_path }}
     - template: jinja
+{% if 'source' not in nginx.server.config %} 
     - context:
         config: {{ nginx.server.config|json() }}
+{% endif %}

--- a/nginx/ng/servers_config.sls
+++ b/nginx/ng/servers_config.sls
@@ -85,15 +85,22 @@ nginx_server_available_dir:
 # Managed enabled/disabled state for servers
 {% for server, settings in nginx.servers.managed.items() %}
 {% if settings.config != None %}
+{% if 'source' in settings.config %}
+{% set source_path = settings.config.source %}
+{% else %}
+{% set source_path = 'salt://nginx/ng/files/server.conf' %}
+{% endif %}
 {% set conf_state_id = 'server_conf_' ~ loop.index0 %}
 {{ conf_state_id }}:
   file.managed:
     {{ sls_block(nginx.servers.managed_opts) }}
     - name: {{ server_curpath(server) }}
-    - source: salt://nginx/ng/files/server.conf
+    - source: {{ source_path }}
     - template: jinja
+{% if 'source' not in settings.config %}
     - context:
         config: {{ settings.config|json() }}
+{% endif %}
     {% if 'overwrite' in settings and settings.overwrite == False %}
     - unless:
       - test -e {{ server_curpath(server) }}

--- a/nginx/ng/servers_config.sls
+++ b/nginx/ng/servers_config.sls
@@ -85,8 +85,8 @@ nginx_server_available_dir:
 # Managed enabled/disabled state for servers
 {% for server, settings in nginx.servers.managed.items() %}
 {% if settings.config != None %}
-{% if 'source' in settings.config %}
-{% set source_path = settings.config.source %}
+{% if 'source_path' in settings.config %}
+{% set source_path = settings.config.source_path %}
 {% else %}
 {% set source_path = 'salt://nginx/ng/files/server.conf' %}
 {% endif %}
@@ -97,7 +97,7 @@ nginx_server_available_dir:
     - name: {{ server_curpath(server) }}
     - source: {{ source_path }}
     - template: jinja
-{% if 'source' not in settings.config %}
+{% if 'source_path' not in settings.config %}
     - context:
         config: {{ settings.config|json() }}
 {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -77,7 +77,7 @@ nginx:
       # nginx.conf (main server) declarations
       # dictionaries map to blocks {} and lists cause the same declaration to repeat with different values
       config: 
-        source: salt://path_to_nginx_conf_file/nginx.conf # IMPORTANT: This option is mutually exclusive with the rest of the
+        source_path: salt://path_to_nginx_conf_file/nginx.conf # IMPORTANT: This option is mutually exclusive with the rest of the
                                                           # options; if it is found other options (worker_processes: 4 and so 
                                                           # on) are not processed and just upload the file from source
         worker_processes: 4
@@ -141,12 +141,12 @@ nginx:
           #        test something else;
           #    }
           # }         
-        mysite2: # Using source options to upload the file instead of templating all the file
+        mysite2: # Using source_path options to upload the file instead of templating all the file
           enabled: True
           available_dir: /etc/nginx/sites-available
           enabled_dir: /etc/nginx/sites-enabled
           config:
-            source: salt://path-to-site-file/mysite2
+            source_path: salt://path-to-site-file/mysite2
 
     certificates_path: '/etc/nginx/ssl'  # Use this if you need to deploy below certificates in a custom path.
     # If you're doing SSL termination, you can deploy certificates this way.

--- a/pillar.example
+++ b/pillar.example
@@ -77,6 +77,9 @@ nginx:
       # nginx.conf (main server) declarations
       # dictionaries map to blocks {} and lists cause the same declaration to repeat with different values
       config: 
+        source: salt://path_to_nginx_conf_file/nginx.conf # IMPORTANT: This option is mutually exclusive with the rest of the
+                                                          # options; if it is found other options (worker_processes: 4 and so 
+                                                          # on) are not processed and just upload the file from source
         worker_processes: 4
         pid: /var/run/nginx.pid		### Directory location must exist
         events:
@@ -138,6 +141,12 @@ nginx:
           #        test something else;
           #    }
           # }         
+        mysite2: # Using source options to upload the file instead of templating all the file
+          enabled: True
+          available_dir: /etc/nginx/sites-available
+          enabled_dir: /etc/nginx/sites-enabled
+          config:
+            source: salt://path-to-site-file/mysite2
 
     certificates_path: '/etc/nginx/ssl'  # Use this if you need to deploy below certificates in a custom path.
     # If you're doing SSL termination, you can deploy certificates this way.


### PR DESCRIPTION
 Enable the uploading of the different config files (nginx.conf and sites) instead of templating just adding ``source`` word in the config section (check pillar.example). In some cases can be interesting to have this possibility.

Tested in Ubuntu 14/16 and CentOS 6/7.