### PR TITLE
Fix for PR #172

### DIFF
--- a/nginx/ng/servers_config.sls
+++ b/nginx/ng/servers_config.sls
@@ -126,6 +126,9 @@ nginx_server_available_dir:
 
 {% if settings.enabled != None %}
 {% set status_state_id = 'server_state_' ~ loop.index0 %}
+{%- set enabled_dir = path_join(server, nginx.servers.managed.get(server).get('enabled_dir', nginx.lookup.server_enabled)) -%}
+{%- set available_dir = path_join(server, nginx.servers.managed.get(server).get('available_dir', nginx.lookup.server_available)) -%}
+{%- if enabled_dir != available_dir %}
 {{ status_state_id }}:
 {% if 'deleted' in settings and settings.deleted %}
 {{ manage_status(server, False, True) }}
@@ -140,5 +143,6 @@ nginx_server_available_dir:
 {% if 'deleted' not in settings or ( 'deleted' in settings and settings.deleted == False ) %}
 {% do server_states.append(status_state_id) %}
 {% endif %}
+{%- endif %} {# enabled != available_dir #}
 {% endif %}
 {% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -152,6 +152,25 @@ nginx:
           config:
             source_path: salt://path-to-site-file/mysite2
 
+        # Below configuration becomes handy if you want to create custom configuration files
+        # for example if you want to create /usr/local/etc/nginx/http_options.conf with
+        # the following content:
+
+        # sendfile on;
+        # tcp_nopush on;
+        # tcp_nodelay on;
+        # send_iowait 12000;
+
+        http_options.conf:
+          enabled: True
+          available_dir: /usr/local/etc/nginx
+          enabled_dir: /usr/local/etc/nginx
+          config:
+            - sendfile: 'on'
+            - tcp_nopush: 'on'
+            - tcp_nodelay: 'on'
+            - send_iowait: 12000
+
     certificates_path: '/etc/nginx/ssl'  # Use this if you need to deploy below certificates in a custom path.
     # If you're doing SSL termination, you can deploy certificates this way.
     # The private one(s) should go in a separate pillar file not in version


### PR DESCRIPTION
Fix for #172

What this PR does is to allow users to have this pillar data:

```yaml
nginx:
  ng:
    servers:
      managed:
        http_options.conf:
          enabled: True
          available_dir: /usr/local/etc/nginx
          enabled_dir: /usr/local/etc/nginx
          config:
            - sendfile: 'on'
            - tcp_nopush: 'on'
            - tcp_nodelay: 'on'
            - send_iowait: 12000
```

To generate a file called **/usr/local/etc/nginx/http_options.conf** with the content:

```
sendfile on;
tcp_nopush on;
tcp_nodelay on;
send_iowait 12000;
```

Without this patch a symlink is created in **/usr/local/etc/nginx/sites-enabled/http_options.conf** and **this is not desired**.