### PR TITLE
 Servers config should require available/enabled dirs

### DIFF
--- a/nginx/ng/map.jinja
+++ b/nginx/ng/map.jinja
@@ -145,7 +145,9 @@
         'disabled_postfix': '.disabled',
         'symlink_opts': {},
         'rename_opts': {},
-        'managed_opts': {},
+        'managed_opts': {
+            'makedirs': True,
+            },
         'dir_opts': {
             'makedirs': True,
         },

--- a/nginx/ng/servers_config.sls
+++ b/nginx/ng/servers_config.sls
@@ -112,6 +112,8 @@ nginx_server_available_dir:
     - name: {{ server_curpath(server) }}
     - source: {{ source_path }}
     - template: jinja
+    - require_in:
+      - service: nginx_service
 {% if 'source_path' not in settings.config %}
     - context:
         config: {{ settings.config|json() }}


### PR DESCRIPTION
This PR does the following:

- Servers config should require available/enabled dirs to avoid race-conditions (Creating a config file without this PR failed because parent dir didn't exist).

- NGiNX service should depend on servers config.

- Servers config should create parent directories (For not common paths).

Thanks!