### PR TITLE
Add ca certificate option

### DIFF
--- a/nginx/ng/certificates.sls
+++ b/nginx/ng/certificates.sls
@@ -50,4 +50,14 @@ nginx_{{ domain }}_ssl_key:
     - watch_in:
       - service: nginx_service
 {% endif %}
+
+{% if salt['pillar.get']("nginx:ng:certificates:{}:ca_cert".format(domain)) %}
+nginx_{{ domain }}_ca_cert:
+  file.managed:
+    - name: {{ certificates_path }}/{{ domain }}-ca.crt
+    - makedirs: True
+    - contents_pillar: nginx:ng:certificates:{{ domain }}:ca_cert
+    - watch_in:
+      - service: nginx_service
+{% endif %}
 {%- endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -175,6 +175,10 @@ nginx:
     # If you're doing SSL termination, you can deploy certificates this way.
     # The private one(s) should go in a separate pillar file not in version
     # control (or use encrypted pillar data).
+
+    # ca_cert is useful for ssl_stapling (http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_stapling)
+    # it will create a file called www.example.com-ca.crt with the content from pillar
+
     certificates:
       'www.example.com':
         public_cert: |
@@ -191,6 +195,13 @@ nginx:
           -----BEGIN RSA PRIVATE KEY-----
           (Your Private Key: www.example.com.key)
           -----END RSA PRIVATE KEY-----
+        ca_cert:
+          -----BEGIN CERTIFICATE-----
+          (Your Intermediate certificate: ExampleCA.crt)
+          -----END CERTIFICATE-----
+          -----BEGIN CERTIFICATE-----
+          (Your Root certificate: TrustedRoot.crt)
+          -----END CERTIFICATE-----
 
     dh_param:
       'mydhparam1.pem': |


### PR DESCRIPTION
This PR address the problem when you want to have only a file containing the CA certificate or chain to be used by [ssl_stapling](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_stapling) feature.