### PR TITLE
ng/servers_config: create dirs for config files

### DIFF
--- a/nginx/ng/servers_config.sls
+++ b/nginx/ng/servers_config.sls
@@ -45,6 +45,7 @@
     {{ sls_block(nginx.servers.symlink_opts) }}
     - name: {{ server_path(server, state) }}
     - target: {{ server_path(server, anti_state) }}
+    - makedirs: True
     {%- else %}
         {%- if deleted == True %}
   file.absent:
@@ -111,6 +112,7 @@ nginx_server_available_dir:
     {{ sls_block(nginx.servers.managed_opts) }}
     - name: {{ server_curpath(server) }}
     - source: {{ source_path }}
+    - makedirs: True
     - template: jinja
 {% if 'source_path' not in settings.config %}
     - context:


### PR DESCRIPTION
If I will use other config dirs, ex. for stream function, nginx will failed because folders don't exist.

With this PR, this formula will create the folders itself.

Ex, my pillar extension:

nginx:
  ng:
    server:
        stream:
          include:
            - /etc/nginx/stream-enabled/*
    servers:
      managed:
        mystream:
          enabled: True
          available_dir: /etc/nginx/stream-available
          enabled_dir: /etc/nginx/stream-enabled
          config:
            - server:
              - listen:
                - 4000
              - proxy_pass: backend.localdomain:3389
