### PR TITLE
Allow to use load_module directly

### DIFF
--- a/nginx/ng/files/nginx.conf
+++ b/nginx/ng/files/nginx.conf
@@ -32,6 +32,10 @@
 #
 # This file is managed by Salt.
 
+{% if 'load_module' in config.keys() %}
+{{ nginx_block(config.pop('load_module'), 'load_module') }}
+{%- endif -%}
+
 {% if 'include' in config.keys() %}
 {{ nginx_block(config.pop('include'), 'include') }}
 {%- endif -%}

--- a/pillar.example
+++ b/pillar.example
@@ -85,7 +85,7 @@ nginx:
                                                           # options; if it is found other options (worker_processes: 4 and so
                                                           # on) are not processed and just upload the file from source
         worker_processes: 4
-        load_module: modules/ngx_http_lua_module.so
+        load_module: modules/ngx_http_lua_module.so  # this will be passed very first in configuration; otherwise nginx will fail to start
         pid: /var/run/nginx.pid		### Directory location must exist
         events:
           worker_connections: 768

--- a/pillar.example
+++ b/pillar.example
@@ -85,6 +85,7 @@ nginx:
                                                           # options; if it is found other options (worker_processes: 4 and so
                                                           # on) are not processed and just upload the file from source
         worker_processes: 4
+        load_module: modules/ngx_http_lua_module.so
         pid: /var/run/nginx.pid		### Directory location must exist
         events:
           worker_connections: 768


### PR DESCRIPTION
This is similar to https://github.com/saltstack-formulas/nginx-formula/pull/157 but allows to directly specify `load_module` inside `nginx.conf` without loading external files