### PR TITLE
Replace tabs in pillar.example with spaces.

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -86,7 +86,7 @@ nginx:
                                                           # on) are not processed and just upload the file from source
         worker_processes: 4
         load_module: modules/ngx_http_lua_module.so  # this will be passed very first in configuration; otherwise nginx will fail to start
-        pid: /var/run/nginx.pid		### Directory location must exist
+        pid: /var/run/nginx.pid                      # Directory location must exist
         events:
           worker_connections: 768
         http:


### PR DESCRIPTION
tabs cause salt to trigger a render error because tabs are 'illegal':
```
yaml.scanner.ScannerError: while scanning for the next token
found character '\t' that cannot start any token
  in "<unicode string>", line 33, column 32:
            pid: /var/run/nginx.pid\t\t### Directory location must exist
                                   ^
```