### PR TITLE
Allow installation of multiple packages

### DIFF
--- a/nginx/ng/pkg.sls
+++ b/nginx/ng/pkg.sls
@@ -24,7 +24,14 @@
 nginx_install:
   pkg.installed:
     {{ sls_block(nginx.package.opts) }}
+    {% if nginx.lookup.package is iterable and nginx.lookup.package is not string %}
+    - pkgs:
+      {% for pkg in nginx.lookup.package %}
+      - {{ pkg }}
+      {% endfor %}
+    {% else %}
     - name: {{ nginx.lookup.package }}
+    {% endif %}
 
 {% if salt['grains.get']('os_family') == 'Debian' %}
 nginx_official_repo:

--- a/pillar.example
+++ b/pillar.example
@@ -44,7 +44,7 @@ nginx:
     # These are usually set by grains in map.jinja
     # Typically you can comment these out.
     lookup:
-      package: nginx-custom
+      package: nginx-custom (can be a list)
       service: nginx
       webuser: www-data
       conf_file: /etc/nginx/nginx.conf


### PR DESCRIPTION
Hello,

It could be useful to be able to install multiple packages such as *Nginx* modules.

If the user wants to setup virtualhosts which are using directives provided by a module, the package installation as to be performed before the restart of the service to prevent errors.

Thanks.