### PR TITLE
Fix syntax for nginx reverse proxy

### DIFF
--- a/nginx/ng/files/server.conf
+++ b/nginx/ng/files/server.conf
@@ -7,7 +7,7 @@
             {%- for k, v in value.items() -%}
                 {%- if v is number or v is string -%}
 {{ server_config([v], k, ind) }}
-                {%- elif v|length() > 0 and (v[0] is number or v[0] is string) -%}
+                {%- elif (v|length() > 0 and v[0] is number) or (v|length() > 0 and v[0] is string and "location" not in k) -%}
 {{ lb }}{{ k|indent(ind,True) }}{{ server_config(v,'', 0, '', '')}}{{ delim }}
                 {%- else %}
 {{ lb }}{{ k|indent(ind, True) }} {{ '{' }}


### PR DESCRIPTION
This PR fixes **location** syntax when configuring reverse proxy. Otherwise nginx service fails.

**ISSUE:**  
location syntax does not comply with [documentation](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/#passing-a-request-to-a-proxied-server)
```
$ cat /etc/nginx/sites-available/default 
# Nginx server configuration
#
# **** DO NOT EDIT THIS FILE ****
#
# This file is managed by Salt.
server {
    root /var/www/html;
    server_name _;
    listen 8080 default_server;
    listen [::]:8080 default_server;
    index index.html index.htm index.nginx-debian.html;
    location /v3/ proxy_pass http://192.168.1.8/identity/v3/;
    location /v1beta/ proxy_pass http://192.168.1.8:50040//v0.3.3/;
}
```

**SOLUTION**
The PR was verified on Ubuntu 18.
```
$ cat /etc/nginx/sites-available/default 
# Nginx server configuration
#
# **** DO NOT EDIT THIS FILE ****
#
# This file is managed by Salt.
server {
    root /var/www/html;
    server_name _;
    listen 8080 default_server;
    listen [::]:8080 default_server;
    index index.html index.htm index.nginx-debian.html;

    location /v3/ {
         proxy_pass http://192.168.1.8/identity/v3/;
    }

    location /v1beta/ {
         proxy_pass http://192.168.1.8:50040//v0.3.3/;
    }
}
```
