### PR TITLE
makedirs needed for 'available_dir' pillar

### DIFF
--- a/nginx/ng/servers_config.sls
+++ b/nginx/ng/servers_config.sls
@@ -111,6 +111,7 @@ nginx_server_available_dir:
     {{ sls_block(nginx.servers.managed_opts) }}
     - name: {{ server_curpath(server) }}
     - source: {{ source_path }}
+    - makedirs: True
     - template: jinja
     - require_in:
       - service: nginx_service


### PR DESCRIPTION
This PR fixes bug that happens if `available_dir` does not exist.
```
 ID: server_conf_0
    Function: file.managed
        Name: /etc/nginx/sites-available/default
      Result: False
     Comment: Parent directory not present
     Started: 15:46:29.381363
    Duration: 33.871 ms
     Changes:   

```