### PR TITLE
Document pid_file pillar for nginx state (#96)

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,19 +1,24 @@
-# nginx:
-   install_from_source: True
-   use_upstart: True
-   use_sysvinit: False
-   user_auth_enabled: True
-   with_luajit: False
-   with_openresty: True
-   repo_version: development  # Must be using ppa install by setting `repo_source = ppa`
-   set_real_ips: # NOTE: to use this, nginx must have http_realip module enabled
-     from_ips:
-       - 10.10.10.0/24
-     real_ip_header: X-Forwarded-For
-   modules:
-     headers-more:
-       source: http://github.com/agentzh/headers-more-nginx-module/tarball/v0.21
-       source_hash: sha1=dbf914cbf3f7b6cb7e033fa7b7c49e2f8879113b
+#=====
+# nginx: see `nginx.ng` state instead.
+#======
+nginx:
+  install_from_source: True
+  use_upstart: True
+  use_sysvinit: False
+  user_auth_enabled: True
+  with_luajit: False
+  with_openresty: True
+  repo_version: development  # Must be using ppa install by setting `repo_source = ppa`
+  set_real_ips: # NOTE: to use this, nginx must have http_realip module enabled
+    from_ips:
+      - 10.10.10.0/24
+    real_ip_header: X-Forwarded-For
+  modules:
+    headers-more:
+      source: http://github.com/agentzh/headers-more-nginx-module/tarball/v0.21
+      source_hash: sha1=dbf914cbf3f7b6cb7e033fa7b7c49e2f8879113b
+  #pid: /var/run/nginx.pid
+             # Directory location must exist (i.e. it's  /run/nginx.pid on EL7)
 
 # ========
 # nginx.ng
@@ -59,7 +64,7 @@ nginx:
       rh_os_releasever: '6'
       # Currently it can be used on rhel/centos/suse when installing from repo
       gpg_check: True
-      pid_file: /var/run/nginx.pid   ### Prevent Rendering SLS error (map.jinja:149) if nginx.server.config.pid undefined (Ubuntu, etc) ###
+      pid_file: /var/run/nginx.pid   ### prevents rendering SLS error nginx.server.config.pid undefined ###
 
 
     # Source compilation is not currently a part of nginx.ng
@@ -91,8 +96,8 @@ nginx:
                                                           # options; if it is found other options (worker_processes: 4 and so
                                                           # on) are not processed and just upload the file from source
         worker_processes: 4
-        load_module: modules/ngx_http_lua_module.so  # this will be passed very first in configuration; otherwise nginx will fail to start
-        pid: /var/run/nginx.pid                      # Directory location must exist
+        load_module: modules/ngx_http_lua_module.so  # pass as very first in configuration; otherwise nginx will fail to start
+        #pid: /var/run/nginx.pid                     # Directory location must exist (i.e. it's  /run/nginx.pid on EL7)
         events:
           worker_connections: 768
         http:


### PR DESCRIPTION
This PR fully resolves #96.  
The `pid_file` is already documented for `nginx.ng` but missing for `nginx` pillar example [Fixed]
There was also some incorrect indention for `nginx` pillar.example [Fixed]