### PR TITLE
fix: corrected indentation on context in file.managed states

### DIFF
--- a/nginx/common.sls
+++ b/nginx/common.sls
@@ -45,8 +45,8 @@
     - require:
       - file: {{ conf_dir }}
     - context:
-      default_user: {{ nginx_map.default_user }}
-      default_group: {{ nginx_map.default_group }}
+        default_user: {{ nginx_map.default_user }}
+        default_group: {{ nginx_map.default_group }}
 
 {% if nginx.get('init_conf_dirs', True) %}
 {% for dir in ('sites-enabled', 'sites-available') %}

--- a/nginx/ng/passenger.sls
+++ b/nginx/ng/passenger.sls
@@ -30,7 +30,7 @@ passenger_config:
     - source: salt://nginx/ng/files/nginx.conf
     - template: jinja
     - context:
-      config: {{ nginx.passenger|json() }}
+        config: {{ nginx.passenger|json() }}
     - watch_in:
       - service: nginx_service
     - require_in:

--- a/nginx/source.sls
+++ b/nginx/source.sls
@@ -239,9 +239,9 @@ nginx:
     - group: root
     - mode: 0755
     - context:
-      service_name: {{ service_name }}
-      sbin_dir: {{ sbin_dir }}
-      pid_path: {{ pid_path }}
+        service_name: {{ service_name }}
+        sbin_dir: {{ sbin_dir }}
+        pid_path: {{ pid_path }}
 {% endif %}
   service:
 {% if service_enable %}

--- a/nginx/sysvinit.sls
+++ b/nginx/sysvinit.sls
@@ -19,7 +19,7 @@ nginx-logger-{{ log_type }}:
       - salt://nginx/templates/{{ grains['os_family'] }}-sysvinit-logger.jinja
       - salt://nginx/templates/sysvinit-logger.jinja
     - context:
-      type: {{ log_type }}
+        type: {{ log_type }}
   service:
     - running
     - enable: True

--- a/nginx/upstart.sls
+++ b/nginx/upstart.sls
@@ -14,7 +14,7 @@ nginx-logger-{{ log_type }}:
     - mode: 440
     - source: salt://nginx/templates/upstart-logger.jinja
     - context:
-      type: {{ log_type }}
+        type: {{ log_type }}
   service:
     - running
     - enable: True


### PR DESCRIPTION
When indentation in `context` is wrong, it can lead to errors, see https://github.com/daks/saltbug-formula for an example.