### PR TITLE
Updating log_format in pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -135,8 +135,10 @@ nginx:
 
           ### module ngx_http_log_module example
           log_format: |-
-            main '...';
-              access_log /var/log/nginx/access_log main
+            main '$remote_addr - $remote_user [$time_local] $status '
+                                '"$request" $body_bytes_sent "$http_referer" '
+                                '"$http_user_agent" "$http_x_forwarded_for"';
+              access_log /var/log/nginx/access.log main
           access_log: []       #suppress default access_log option from being added
 
         ### module nngx_stream_core_module

--- a/pillar.example
+++ b/pillar.example
@@ -137,8 +137,7 @@ nginx:
           log_format: |-
             main '$remote_addr - $remote_user [$time_local] $status '
                                 '"$request" $body_bytes_sent "$http_referer" '
-                                '"$http_user_agent" "$http_x_forwarded_for"';
-              access_log /var/log/nginx/access.log main
+                                '"$http_user_agent" "$http_x_forwarded_for"'
           access_log: []       #suppress default access_log option from being added
 
         ### module nngx_stream_core_module


### PR DESCRIPTION
Continuing changes discussed in #217.

The main issue that needs discussing/testing is whether the `access_log` line (141 after this first commit) still needs to be part of `log_format` as a workaround (see #122) rather than just using the following line to specify it in YAML format.