### PR TITLE
fix: prevent running of states deprecated in `v1.0.0`

### DIFF
--- a/nginx/common.sls
+++ b/nginx/common.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/deprecated.sls
+++ b/nginx/deprecated.sls
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+nginx-deprecated-in-v1.0.0-test-fail:
+  test.fail_without_changes:
+    - name: |
+
+
+        ################################################################################
+        #                                                                              #
+        #                   WARNING: BREAKING CHANGES SINCE `v1.0.0`                   #
+        #                                                                              #
+        ################################################################################
+        #                                                                              #
+        # Prior to `v1.0.0`, this formula provided two methods for managing NGINX; the #
+        # old method under `nginx` and the new method under `nginx.ng`. The old method #
+        # has now been removed and `nginx.ng` has been promoted to be `nginx` in its   #
+        # place.                                                                       #
+        #                                                                              #
+        # If you are not in a position to migrate, please pin your repo to the final   #
+        # release tag before `v1.0.0`, i.e. `v0.56.1`.                                 #
+        #                                                                              #
+        # To migrate from `nginx.ng`, simply modify your pillar to promote the entire  #
+        # section under `nginx:ng` so that it is under `nginx` instead. So with the    #
+        # editor of your choice, highlight the entire section and then unindent one    #
+        # level. Finish by removing the `ng:` line.                                    #
+        #                                                                              #
+        # To migrate from the old `nginx`, first convert to `nginx.ng` under `v0.56.1` #
+        # and then follow the steps laid out in the paragraph directly above.          #
+        #                                                                              #
+        ################################################################################
+    - failhard: True

--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -2,14 +2,17 @@
 #
 # Meta-state to fully install nginx.
 
-{% from 'nginx/map.jinja' import nginx, sls_block with context %}
+{%- from 'nginx/map.jinja' import nginx, sls_block with context %}
 
 include:
+  {%- if nginx.ng is defined %}
+  - nginx.deprecated
+  {%- endif %}
   - nginx.config
   - nginx.service
-  {% if nginx.snippets is defined %}
+  {%- if nginx.snippets is defined %}
   - nginx.snippets
-  {% endif %}
+  {%- endif %}
   - nginx.servers
   - nginx.certificates
 
@@ -23,8 +26,8 @@ extend:
   nginx_config:
     file:
       - require:
-        {% if nginx.install_from_source %}
+        {%- if nginx.install_from_source %}
         - cmd: nginx_install
-        {% else %}
+        {%- else %}
         - pkg: nginx_install
-        {% endif %}
+        {%- endif %}

--- a/nginx/luajit2.sls
+++ b/nginx/luajit2.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/ng/certificates.sls
+++ b/nginx/ng/certificates.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/ng/config.sls
+++ b/nginx/ng/config.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/ng/init.sls
+++ b/nginx/ng/init.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/ng/passenger.sls
+++ b/nginx/ng/passenger.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/ng/pkg.sls
+++ b/nginx/ng/pkg.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/ng/servers.sls
+++ b/nginx/ng/servers.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/ng/servers_config.sls
+++ b/nginx/ng/servers_config.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/ng/service.sls
+++ b/nginx/ng/service.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/ng/snippets.sls
+++ b/nginx/ng/snippets.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/ng/src.sls
+++ b/nginx/ng/src.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/openresty.sls
+++ b/nginx/openresty.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/package.sls
+++ b/nginx/package.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/source.sls
+++ b/nginx/source.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/sysvinit.sls
+++ b/nginx/sysvinit.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/upstart.sls
+++ b/nginx/upstart.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated

--- a/nginx/users.sls
+++ b/nginx/users.sls
@@ -1,0 +1,2 @@
+include:
+  - nginx.deprecated


### PR DESCRIPTION
* Route all to `nginx/deprecated.sls`

---

Cross-references:

* #232 -- states deprecated.
* #233 -- main discussion about the need for this PR (after the merge).
* #235 -- warning banner added to `README`.

---

Note: There is one common state before and after: `nginx/init.sls`.  For that, I've checked for the presence of `nginx:ng` in the map instead.

Note: Implementation based on [this PR](https://github.com/saltstack-formulas/template-formula/pull/91).