### PR TITLE
fix(snippet-file-name): removed appending of ".conf" for snippets files

### DIFF
--- a/nginx/snippets.sls
+++ b/nginx/snippets.sls
@@ -14,7 +14,7 @@ nginx_snippets_dir:
 {% for snippet, config in nginx.snippets.items() %}
 nginx_snippet_{{ snippet }}:
   file.managed:
-    - name: {{ nginx.lookup.snippets_dir ~ '/' ~ snippet ~ '.conf' }}
+    - name: {{ nginx.lookup.snippets_dir ~ '/' ~ snippet }}
     - source: {{ files_switch([ snippet, 'server.conf' ],
                               'nginx_snippet_file_managed'
                  )

--- a/pillar.example
+++ b/pillar.example
@@ -63,15 +63,15 @@ nginx:
   ## Files or Templates can be retrieved by TOFS with snippet name ( Fallback to server.conf )
   ##--- --- - - - - - - --  - - -- -- - - --- -- - -- - - - -- - - - - -- - - - -- - - - -- - ##
   snippets:
-    letsencrypt:
+    letsencrypt.conf:
       - location ^~ /.well-known/acme-challenge/:
         - proxy_pass: http://localhost:9999
-    cloudflare_proxy:
+    cloudflare_proxy.conf:
       - set_real_ip_from: 103.21.244.0/22
       - set_real_ip_from: 103.22.200.0/22
       - set_real_ip_from: 104.16.0.0/12
       - set_real_ip_from: 108.162.192.0/18
-    blacklist:
+    blacklist.conf:
       - map $http_user_agent $bad_bot:
         - default: 0
         - '~*^Lynx': 0
@@ -81,7 +81,7 @@ nginx:
         - '~*bandit': 1
         - libwww-perl: 1
         - '~(?i)(httrack|htmlparser|libwww)': 1
-    upstream_netdata_tcp:
+    upstream_netdata_tcp.conf:
       - upstream netdata:
         - server: 127.0.0.1:19999
         - keepalive: 64

--- a/test/salt/default/pillar/nginx.sls
+++ b/test/salt/default/pillar/nginx.sls
@@ -6,7 +6,7 @@
 
 nginx:
   snippets:
-    letsencrypt:
+    letsencrypt.conf:
       - location ^~ /.well-known/acme-challenge/:
         - proxy_pass: http://localhost:9999
   server:


### PR DESCRIPTION
Since introduction of TOFS in this formula,  we can retrieve file that are not described by pillar. TOFS  will generate source like the following:
```
nginx_snippet_letsencrypt:
              source:
                  - salt://nginx/files/snippets/letsencrypt
                  - salt://nginx/files/snippets/server.conf
                  - salt://nginx/files/A/B/C/letsencrypt
                  - salt://nginx/files/A/B/C/server.conf
                  - salt://nginx/files/FreeBSD/letsencrypt
                  - salt://nginx/files/FreeBSD/server.conf
                  - salt://nginx/files/default/letsencrypt
                  - salt://nginx/files/default/server.conf
```
However, we have not same behavior between snippets file and `server_config`s.
Actually formula, append `.conf` as an extension for all snippets.
If we include `snippets/*.conf` in the main nginx.conf for example, it is not always the case that we desire to include all snippets.
This PR propose to remove the appending of '.conf' for snippets files and permit to choose file name and extension for snippets with snippet name.