### PR TITLE
tofs: include path pattern with defaults in docs

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -299,9 +299,11 @@ nginx:
     #   - osfinger
     #   - os
     #   - os_family
+    #
     # All aspects of path/file resolution are customisable using the options below.
     # This is unnecessary in most cases; there are sensible defaults.
-    # path_prefix: template_alt
+    # Path pattern: salt://{{ path_prefix or 'nginx' }}/{{ dirs.files or 'files' }}/{{ dirs.default or 'default' }}
+    # path_prefix: template_alt 
     # dirs:
     #   files: files_alt
     #   default: default_alt


### PR DESCRIPTION
This is a suggested one-liner update to docs to clarify how tofs paths work in this formula