### PR TITLE
Included snippets, servers & certs for passenger

### DIFF
--- a/nginx/passenger.sls
+++ b/nginx/passenger.sls
@@ -10,7 +10,13 @@
 {% if salt['grains.get']('os_family') in ['Debian', 'RedHat'] %}
 include:
   - nginx.pkg
+  - nginx.config
   - nginx.service
+  {%- if nginx.snippets is defined %}
+  - nginx.snippets
+  {%- endif %}
+  - nginx.servers
+  - nginx.certificates
 
 passenger_install:
   pkg.installed:


### PR DESCRIPTION
As it stands, including `nginx.passenger` doesn't do enough to result in a working install, unlike `nginx`. In my usecase, we want to be able to swap between `nginx` and `nginx.passenger` and have them be interchangeable with the same behaviour, bar the additional install & config behaviour for passenger.

IMO, that could be structured in a few ways:

1. Reuse the nginx state:

Including the state `nginx` with `install_from_phusionpassenger: true` in your pillar installs passenger + does everything that the nginx state does - if you only include nginx.passenger, you only get the passenger install same as now

2. Addon:

Treat the passenger state as an addon - so in top.sls you define:
- nginx
- nginx.passenger

Buuut in that case I think order is confusing and going to cause problems.

3. Simple: just update passenger to work the same way as nginx (as in this PR)

I'm using this on my fork.
