### PR TITLE
feat(add a purge dir option): add the option to purge sites-enable / …

### DIFF
--- a/nginx/map.jinja
+++ b/nginx/map.jinja
@@ -162,6 +162,7 @@
             'makedirs': True,
         },
         'managed': {},
+        'purge_servers_config': False,
     },
     'passenger': {
         'passenger_root': '/usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini',

--- a/nginx/servers_config.sls
+++ b/nginx/servers_config.sls
@@ -83,6 +83,7 @@ nginx_server_enabled_dir:
   file.directory:
     {{ sls_block(nginx.servers.dir_opts) }}
     - name: {{ nginx.lookup.server_enabled }}
+    - clean: {{ nginx.servers.purge_servers_config }}
 
 # If enabled and available are not the same, create available
 {% if nginx.lookup.server_enabled != nginx.lookup.server_available -%}
@@ -90,6 +91,7 @@ nginx_server_available_dir:
   file.directory:
     {{ sls_block(nginx.servers.dir_opts) }}
     - name: {{ nginx.lookup.server_available }}
+    - clean: {{ nginx.servers.purge_servers_config }}
 {%- endif %}
 
 # Manage the actual server files

--- a/pillar.example
+++ b/pillar.example
@@ -174,6 +174,9 @@ nginx:
     # partially exposes file.directory params for site available/enabled and
     # snippets dirs
     dir_opts: {}
+    # let the choice to purge site-available and site-enable folders before add new ones
+    # (if True it removes all non-salt-managed files)
+    purge_servers_config: false
 
 
     #####################


### PR DESCRIPTION
…sites-available folder before apply new one



### PR progress checklist (to be filled in by reviewers)

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?

#### Primary type

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [X] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?

No.

### Related issues and/or pull requests

N/A

### Describe the changes you're proposing

Add a pillar to have the option to purge the sites-avaliable / sites-enable before applying new ones

### Pillar / config required to test the proposed changes

nginx:servers:purge_servers_config: (True/False)

### Debug log showing how the proposed changes work


### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [X] Updated `pillar.example`.

### Testing checklist

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context



