### PR TITLE
Make openSUSE devel repository optional

### DIFF
--- a/nginx/map.jinja
+++ b/nginx/map.jinja
@@ -116,6 +116,7 @@
     'install_from_ppa': False,
     'install_from_repo': False,
     'install_from_phusionpassenger': False,
+    'install_from_opensuse_devel': False,
     'check_config_before_apply': False,
     'ppa_version': 'stable',
     'source_version': '1.10.0',

--- a/nginx/map.jinja
+++ b/nginx/map.jinja
@@ -72,7 +72,8 @@
             'server_use_symlink': False,
             'pid_file': '/run/nginx.pid',
             'gpg_check': True,
-            'gpg_key': 'http://download.opensuse.org/repositories/server:/http/openSUSE_{{ grains.osrelease }}/repodata/repomd.xml.key',
+            'gpg_key': 'http://download.opensuse.org/repositories/server:/http/{{ grains.osrelease }}/repodata/repomd.xml.key',
+            'gpg_autoimport': True,
             'openssl_package': 'openssl',
         },
         'Arch': {

--- a/nginx/pkg.sls
+++ b/nginx/pkg.sls
@@ -145,12 +145,9 @@ nginx_phusionpassenger_repo:
 {% if grains.os_family == 'Suse' or grains.os == 'SUSE' %}
 nginx_zypp_repo:
   pkgrepo:
+    - name: server_http
     {%- if from_opensuse_devel %}
     - managed
-    {%- else %}
-    - absent
-    {%- endif %}
-    - name: server_http
     - humanname: server_http
     - baseurl: 'http://download.opensuse.org/repositories/server:/http/{{ grains.osrelease }}/'
     - enabled: True
@@ -158,6 +155,9 @@ nginx_zypp_repo:
     - gpgcheck: {{ nginx.lookup.gpg_check }}
     - gpgkey: {{ nginx.lookup.gpg_key }}
     - gpgautoimport: {{ nginx.lookup.gpg_autoimport }}
+    {%- else %}
+    - absent
+    {%- endif %}
     - require_in:
       - pkg: nginx_install
     - watch_in:

--- a/nginx/pkg.sls
+++ b/nginx/pkg.sls
@@ -143,11 +143,12 @@ nginx_zypp_repo:
     {%- endif %}
     - name: server_http
     - humanname: server_http
-    - baseurl: 'http://download.opensuse.org/repositories/server:/http/openSUSE_13.2/'
+    - baseurl: 'http://download.opensuse.org/repositories/server:/http/{{ grains.osrelease }}/'
     - enabled: True
     - autorefresh: True
     - gpgcheck: {{ nginx.lookup.gpg_check }}
     - gpgkey: {{ nginx.lookup.gpg_key }}
+    - gpgautoimport: {{ nginx.lookup.gpg_autoimport }}
     - require_in:
       - pkg: nginx_install
     - watch_in:

--- a/nginx/pkg.sls
+++ b/nginx/pkg.sls
@@ -11,18 +11,27 @@
   {% set from_official = true %}
   {% set from_ppa = false %}
   {% set from_phusionpassenger = false %}
+  {% set from_opensuse_devel = false %}
 {% elif nginx.install_from_ppa %}
   {% set from_official = false %}
   {% set from_ppa = true %}
   {% set from_phusionpassenger = false %}
+  {% set from_opensuse_devel = false %}
 {% elif nginx.install_from_phusionpassenger %}
   {% set from_official = false %}
   {% set from_ppa = false %}
   {% set from_phusionpassenger = true %}
+  {% set from_opensuse_devel = false %}
+{% elif nginx.install_from_opensuse_devel %}
+  {% set from_official = false %}
+  {% set from_ppa = false %}
+  {% set from_phusionpassenger = false %}
+  {% set from_opensuse_devel = true %}
 {% else %}
   {% set from_official = false %}
   {% set from_ppa = false %}
   {% set from_phusionpassenger = false %}
+  {% set from_opensuse_devel = false %}
 {%- endif %}
 
 {%- set resource_repo_managed = 'file' if grains.os_family == 'Debian' else 'pkgrepo' %}
@@ -136,7 +145,7 @@ nginx_phusionpassenger_repo:
 {% if grains.os_family == 'Suse' or grains.os == 'SUSE' %}
 nginx_zypp_repo:
   pkgrepo:
-    {%- if from_official %}
+    {%- if from_opensuse_devel %}
     - managed
     {%- else %}
     - absent

--- a/pillar.example
+++ b/pillar.example
@@ -24,6 +24,10 @@ nginx:
   # each build accordingly ( https://launchpad.net/~nginx )
   ppa_version: 'stable'
 
+  # Use openSUSE devel (server:http) repository to install nginx.
+  # If not set, the server_http repository will be removed if it exists.
+  install_from_opensuse_devel: false
+
   # Source install
   source_version: '1.10.0'
   source_hash: ''


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

- use default nginx package by default
- update devel repository URL to 15.4 + enable `gpgautoimport`, as zypper will not add repositories with unknown keys by default, causing the state to fail
- fix pkgrepo.absent bug on openSUSE

```
local:
----------
          ID: nginx_zypp_repo
    Function: pkgrepo.absent
        Name: server_http
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python3.6/site-packages/salt/state.py", line 2215, in call
                  *cdata["args"], **cdata["kwargs"]
                File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 149, in __call__
                  return self.loader.run(run_func, *args, **kwargs)
                File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1203, in run
                  return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
                File "/usr/lib/python3.6/site-packages/contextvars/__init__.py", line 38, in run
                  return callable(*args, **kwargs)
                File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1218, in _run_as
                  return _func_or_method(*args, **kwargs)
                File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1251, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python3.6/site-packages/salt/states/pkgrepo.py", line 648, in absent
                  __salt__["pkg.del_repo"](repo=name, **kwargs)
                File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 149, in __call__
                  return self.loader.run(run_func, *args, **kwargs)
                File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1203, in run
                  return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
                File "/usr/lib/python3.6/site-packages/contextvars/__init__.py", line 38, in run
                  return callable(*args, **kwargs)
                File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1218, in _run_as
                  return _func_or_method(*args, **kwargs)
              TypeError: del_repo() got an unexpected keyword argument 'humanname'
     Started: 03:18:38.809548
    Duration: 22.416 ms
     Changes:   
```

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

Apologies, two types in one PR - if you prefer, I can split the bugfix out, but I figured it goes hand in hand.

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [x] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

Yes.

Users currently using the openSUSE devel repository should decide whether they want to continue using it, requiring them to set `install_from_opensuse_devel: true`, or whether they are fine with switching to the package in the official repository in modern releases of openSUSE (OSS/SLE Update repository on Leap 15.4).

Users on SUSE Linux Enterprise should be encouraged to enable the Web Applications module, which provides an official SUSE build of nginx.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->
n/a


### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

- only install openSUSE devel repository if enabled in the pillar


### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

```
nginx:
  install_from_opensuse_devel: true
```

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

GitHub prevents me from pasting the logs, complaining "Pull request creation failed. Validation failed: Body is too long (maximum is 65536 characters)" and deleting all my existing body content - even if I wrap the snippets in `<details>`.

You can find the output for three months here:
https://paste.opensuse.org/pastes/dea95f9e3be7 (`true`)
https://paste.opensuse.org/pastes/5a351448cbf1 (`false`)

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->

I would appreciate advice on how we can make this change painless for users currently using the devel repository. Should we add a note to the README or add a designated message to the changelog for the next release?
